### PR TITLE
Updated the config flow to set Second Import and Export

### DIFF
--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -514,10 +514,17 @@ class SimulatedBatteryHandle:
             time_since_last_battery_update,
         )
 
-        max_discharge = time_since_last_battery_update * self._max_discharge_rate / 3600
-        max_charge = time_since_last_battery_update * self._max_charge_rate / 3600
+        max_discharge = time_since_last_battery_update * (
+            self._max_discharge_rate / 3600
+        )
+        max_charge = time_since_last_battery_update * (
+            self._max_charge_rate / 3600
+        )
 
-        available_capacity_to_charge = self._battery_size - float(self._charge_state)
+        available_capacity_to_charge = (
+            self._battery_size - float(self._charge_state)
+        )
+
         available_capacity_to_discharge = float(self._charge_state) * float(
             self._battery_efficiency
         )
@@ -550,16 +557,25 @@ class SimulatedBatteryHandle:
             _LOGGER.debug("(%s) Battery overide charging.", self._name)
             amount_to_charge = min(max_charge, available_capacity_to_charge)
             amount_to_discharge = 0.0
-            net_export = max(export_amount - amount_to_charge, 0)
-            net_import = max(amount_to_charge - export_amount, 0) + import_amount
+            net_export = (
+                max(export_amount - amount_to_charge, 0)
+            )
+
+            net_import = (
+                max(amount_to_charge - export_amount, 0) + import_amount
+            )
             self._charging = True
             self._sensors[BATTERY_MODE] = MODE_FORCE_CHARGING
 
         if self._switches[FORCE_DISCHARGE]:
             _LOGGER.debug("(%s) Battery forced discharging.", self._name)
             amount_to_charge = 0.0
-            amount_to_discharge = min(max_discharge, available_capacity_to_discharge)
-            net_export = max(amount_to_discharge - import_amount, 0) + export_amount
+            amount_to_discharge = (
+                min(max_discharge, available_capacity_to_discharge)
+            )
+            net_export = (
+                max(amount_to_discharge - import_amount, 0) + export_amount
+            )
             net_import = max(import_amount - amount_to_discharge, 0)
             self._sensors[BATTERY_MODE] = MODE_FORCE_DISCHARGING
 
@@ -630,11 +646,20 @@ class SimulatedBatteryHandle:
             self._sensors[BATTERY_MODE] = MODE_FULL
 
         """Reset day/week/month counters"""
-        if time.strftime("%w") != time.strftime("%w", time.gmtime(time_last_update)):
+        if (
+            time.strftime("%w")
+            != time.strftime("%w", time.gmtime(time_last_update))
+        ):
             self._energy_saved_today = 0
-        if time.strftime("%U") != time.strftime("%U", time.gmtime(time_last_update)):
+        if (
+            time.strftime("%U")
+            != time.strftime("%U", time.gmtime(time_last_update))
+        ):
             self._energy_saved_week = 0
-        if time.strftime("%m") != time.strftime("%m", time.gmtime(time_last_update)):
+        if (
+            time.strftime("%m")
+            != time.strftime("%m", time.gmtime(time_last_update))
+        ):
             self._energy_saved_month = 0
 
         self._last_battery_update_time = time_now

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -251,12 +251,6 @@ class SimulatedBatteryHandle:
             self.reset_sim_sensor,
         )
 
-        async_dispatcher_connect(
-            self._hass,
-            f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}",
-            self.update_battery,
-        )
-
     def async_reset_battery(self):
         """Reset the battery to start over."""
         _LOGGER.debug("Reset battery")
@@ -545,15 +539,7 @@ class SimulatedBatteryHandle:
             else:
                 self._sensors[BATTERY_MODE] = MODE_DISCHARGING
 
-        if self._switches[PAUSE_BATTERY]:
-            _LOGGER.debug("(%s) Battery paused.", self._name)
-            amount_to_charge = 0.0
-            amount_to_discharge = 0.0
-            net_export = export_amount
-            net_import = import_amount
-            self._sensors[BATTERY_MODE] = MODE_IDLE
-
-        if self._switches[OVERIDE_CHARGING]:
+        elif self._switches[OVERIDE_CHARGING]:
             _LOGGER.debug("(%s) Battery overide charging.", self._name)
             amount_to_charge = min(max_charge, available_capacity_to_charge)
             amount_to_discharge = 0.0
@@ -567,7 +553,7 @@ class SimulatedBatteryHandle:
             self._charging = True
             self._sensors[BATTERY_MODE] = MODE_FORCE_CHARGING
 
-        if self._switches[FORCE_DISCHARGE]:
+        elif self._switches[FORCE_DISCHARGE]:
             _LOGGER.debug("(%s) Battery forced discharging.", self._name)
             amount_to_charge = 0.0
             amount_to_discharge = (
@@ -579,7 +565,7 @@ class SimulatedBatteryHandle:
             net_import = max(import_amount - amount_to_discharge, 0)
             self._sensors[BATTERY_MODE] = MODE_FORCE_DISCHARGING
 
-        if self._switches[CHARGE_ONLY]:
+        elif self._switches[CHARGE_ONLY]:
             _LOGGER.debug("(%s) Battery charge only mode.", self._name)
             amount_to_charge: float = min(
                 export_amount, max_charge, available_capacity_to_charge
@@ -592,6 +578,14 @@ class SimulatedBatteryHandle:
                 self._sensors[BATTERY_MODE] = MODE_CHARGING
             else:
                 self._sensors[BATTERY_MODE] = MODE_IDLE
+
+        elif self._switches[PAUSE_BATTERY]:
+            _LOGGER.debug("(%s) Battery paused.", self._name)
+            amount_to_charge = 0.0
+            amount_to_discharge = 0.0
+            net_export = export_amount
+            net_import = import_amount
+            self._sensors[BATTERY_MODE] = MODE_IDLE
 
         current_import_tariff = self.get_tariff_information(
             self._import_tariff_sensor_id

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -3,67 +3,68 @@ import logging, time
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import discovery
-from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
 
 from homeassistant.const import (
-    CONF_NAME,
-    UnitOfEnergy,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfEnergy,
 )
 
 from .const import (
-    CONF_BATTERY,
-    CONF_BATTERY_EFFICIENCY,
-    CONF_BATTERY_MAX_DISCHARGE_RATE,
-    CONF_BATTERY_MAX_CHARGE_RATE,
-    CONF_BATTERY_SIZE,
-    CONF_ENERGY_TARIFF,
-    CONF_ENERGY_IMPORT_TARIFF,
-    CONF_ENERGY_EXPORT_TARIFF,
-    CONF_IMPORT_SENSOR,
-    CONF_SECOND_IMPORT_SENSOR,
-    CONF_SECOND_EXPORT_SENSOR,
-    CONF_EXPORT_SENSOR,
-    DOMAIN,
-    BATTERY_PLATFORMS,
-    OVERIDE_CHARGING,
-    PAUSE_BATTERY,
-    ATTR_ENERGY_SAVED,
-    ATTR_ENERGY_BATTERY_OUT,
     ATTR_ENERGY_BATTERY_IN,
+    ATTR_ENERGY_BATTERY_OUT,
+    ATTR_ENERGY_SAVED,
+    ATTR_MONEY_SAVED_EXPORT,
+    ATTR_MONEY_SAVED_IMPORT,
+    ATTR_MONEY_SAVED,
+    BATTERY_CYCLES,
+    BATTERY_MODE,
+    BATTERY_PLATFORMS,
+    CHARGE_ONLY,
     CHARGING_RATE,
+    CONF_BATTERY_EFFICIENCY,
+    CONF_BATTERY_MAX_CHARGE_RATE,
+    CONF_BATTERY_MAX_DISCHARGE_RATE,
+    CONF_BATTERY_SIZE,
+    CONF_BATTERY,
+    CONF_ENERGY_EXPORT_TARIFF,
+    CONF_ENERGY_IMPORT_TARIFF,
+    CONF_ENERGY_TARIFF,
+    CONF_EXPORT_SENSOR,
+    CONF_IMPORT_SENSOR,
+    CONF_SECOND_EXPORT_SENSOR,
+    CONF_SECOND_IMPORT_SENSOR,
     DISCHARGING_RATE,
+    DOMAIN,
+    FIXED_NUMERICAL_TARIFFS,
+    FORCE_DISCHARGE,
     GRID_EXPORT_SIM,
     GRID_IMPORT_SIM,
-    ATTR_MONEY_SAVED,
-    FORCE_DISCHARGE,
-    BATTERY_MODE,
-    MODE_IDLE,
+    MESSAGE_TYPE_BATTERY_RESET_IMP,
+    MESSAGE_TYPE_BATTERY_RESET_EXP,
+    MESSAGE_TYPE_BATTERY_UPDATE,
+    MESSAGE_TYPE_GENERAL,
     MODE_CHARGING,
     MODE_DISCHARGING,
-    MODE_FULL,
     MODE_EMPTY,
-    MODE_FORCE_DISCHARGING,
     MODE_FORCE_CHARGING,
-    ATTR_MONEY_SAVED_IMPORT,
-    ATTR_MONEY_SAVED_EXPORT,
-    TARIFF_TYPE,
+    MODE_FORCE_DISCHARGING,
+    MODE_FULL,
+    MODE_IDLE,
     NO_TARIFF_INFO,
+    OVERIDE_CHARGING,
+    PAUSE_BATTERY,
     TARIFF_SENSOR_ENTITIES,
-    FIXED_NUMERICAL_TARIFFS,
-    BATTERY_CYCLES,
-    MESSAGE_TYPE_GENERAL,
-    MESSAGE_TYPE_BATTERY_RESET,
-    MESSAGE_TYPE_BATTERY_UPDATE,
-    CHARGE_ONLY,
+    TARIFF_TYPE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,12 +97,14 @@ async def async_setup(hass, config):
 
     if config.get(DOMAIN) is None:
         return True
+    
     for battery, conf in config.get(DOMAIN).items():
         _LOGGER.debug("Setup %s.%s", DOMAIN, battery)
         handle = SimulatedBatteryHandle(conf, hass)
         if battery in hass.data[DOMAIN]:
             _LOGGER.warning("Battery name not unique - not able to create.")
             continue
+        
         hass.data[DOMAIN][battery] = handle
 
         for platform in BATTERY_PLATFORMS:
@@ -120,8 +123,9 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, entry) -> bool:
     """Set up battery platforms from a Config Flow Entry"""
     hass.data.setdefault(DOMAIN, {})
-
+    
     _LOGGER.debug("Setup %s.%s", DOMAIN, entry.data[CONF_NAME])
+   
     handle = SimulatedBatteryHandle(entry.data, hass)
     hass.data[DOMAIN][entry.entry_id] = handle
 
@@ -159,6 +163,7 @@ class SimulatedBatteryHandle:
 
         """Defalt to sensor entites for backwards compatibility"""
         self._tariff_type = TARIFF_SENSOR_ENTITIES
+    
         if TARIFF_TYPE in config:
             self._tariff_type = config[TARIFF_TYPE]
 
@@ -225,14 +230,20 @@ class SimulatedBatteryHandle:
 
         async_dispatcher_connect(
             self._hass,
-            f"{self._name}-{MESSAGE_TYPE_BATTERY_RESET}",
+            f"{self._name}-{MESSAGE_TYPE_BATTERY_RESET_IMP}",
+            self.reset_sim_sensor,
+        )
+        
+        async_dispatcher_connect(
+            self._hass,
+            f"{self._name}-{MESSAGE_TYPE_BATTERY_RESET_EXP}",
             self.reset_sim_sensor,
         )
         
         async_dispatcher_connect(
             self._hass, 
             f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}",
-            self.updateBattery
+            self.update_battery
         )
 
     def async_reset_battery(self):
@@ -269,13 +280,12 @@ class SimulatedBatteryHandle:
 
         if secondary_sensor_id is not None:
             sensor_ids.append(secondary_sensor_id)
-
-        total_sim = sum(
-            float(self._hass.states.get(sid).state or 0.0)
-            for sid in sensor_ids
-            if self._hass.states.get(sid).state
-            not in [STATE_UNAVAILABLE, STATE_UNKNOWN]
-        )
+            
+        total_sim = 0.0 
+        
+        for sid in sensor_ids:
+            if self._hass.states.get(sid).state not in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
+                total_sim += float(self._hass.states.get(sid).state)
 
         self._sensors[target_sensor_key] = total_sim
         dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
@@ -323,6 +333,18 @@ class SimulatedBatteryHandle:
     @callback
     def async_reading_handler(self, event, is_import):
         """Handle the sensor state changes for import or export."""
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        if (
+            old_state is None
+            or new_state is None
+            or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
+            or new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
+        ):
+            return
+
+
         sensor_id = self._import_sensor_id if is_import else self._export_sensor_id
         sensor_type = "import" if is_import else "export"
         sensor_charge_rate = DISCHARGING_RATE if is_import else CHARGING_RATE
@@ -331,67 +353,48 @@ class SimulatedBatteryHandle:
         last_reading_time_attr = f"_last_{sensor_type}_reading_time"
         last_reading_attr = f"_last_{sensor_type}_reading"
 
-        old_state = event.data.get("old_state")
-        new_state = event.data.get("new_state")
-
-        if not (old_state and new_state):
-            return
-
-        units = self._hass.states.get(sensor_id).attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT
-        )
-
+        units = self._hass.states.get(sensor_id).attributes.get( ATTR_UNIT_OF_MEASUREMENT )
+        
         if units not in [UnitOfEnergy.KILO_WATT_HOUR, UnitOfEnergy.WATT_HOUR]:
-            _LOGGER.warning(
-                "Units of %s sensor not recognized - may give wrong results",
-                sensor_type,
-            )
+            _LOGGER.warning( "Units of %s sensor not recognized - may give wrong results", sensor_type )
 
         conversion_factor = 1.0 if units == UnitOfEnergy.KILO_WATT_HOUR else 0.001
 
-        old_state_value = float(old_state.state)
-        new_state_value = float(new_state.state)
+        new_state_value = float(new_state.state) * conversion_factor
+        old_state_value = float(old_state.state) * conversion_factor
+        
+        reading_variance = new_state_value - old_state_value
         
         _LOGGER.debug(f"({self._name}) {sensor_id}: Old = {old_state_value} / New = {new_state_value} ")
-
-        reading_difference = new_state_value - old_state_value
-
-        if reading_difference < 0:
-            _LOGGER.warning(
-                "%s sensor value decreased - meter may have been reset",
-                sensor_type,
-            )
-            self._sensors[sensor_charge_rate] = 0
-            return
-
-        last_reading = getattr(self, last_reading_attr)
-
-        setattr(self, last_reading_time_attr, time.time())
-
-        cumulative_reading = conversion_factor * new_state_value
-        rate_reading = conversion_factor * reading_difference
-
-        _LOGGER.debug(
-            f"Last Reading Time {self._last_import_reading_time} - {self._last_export_reading_time}"
-        )
         
-        if self._last_import_reading_time > self._last_export_reading_time:
-            if self._last_export_reading > 0:
-                _LOGGER.warning("Accumulated reading not cleared error")
-                
-            last_reading = rate_reading
+        if reading_variance < 0:
+            _LOGGER.warning( "(%s) %s sensor value decreased - meter may have been reset", self._name, sensor_type)
+            self._sensors[sensor_charge_rate] = 0
+        
+        if reading_variance >= 0:
+            setattr(self, cumulative_reading_attr, new_state_value)
             
-        else:
-            last_reading += rate_reading
-            import_amount = last_reading if is_import else 0.0
-            export_amount = 0.0 if is_import else last_reading
-            self.updateBattery(import_amount, export_amount)
+            if is_import:
+                self.update_battery(reading_variance, self._last_export_reading)
+                self._last_export_reading = 0.0
+                
+            if not is_import:       
+                if self._last_import_reading_time > self._last_export_reading_time:
+                    if self._last_export_reading > 0:
+                        _LOGGER.warning("(%s) Accumulated export reading not cleared error = ", self._last_export_reading)
+                    
+                    self._last_export_reading = reading_variance
+                    
+                else:
+                    reading_variance += self._last_export_reading
+                    self._last_export_reading = 0.0
+                    self.update_battery(0.0, reading_variance)
+                                                    
+        # Finish the Sensor Reading 
+        setattr(self, last_reading_time_attr, time.time())
+        return
 
-        setattr(self, cumulative_reading_attr, cumulative_reading)
-        setattr(self, sensor_charge_rate, rate_reading)
-        setattr(self, last_reading_attr, last_reading)
-
-    def getTariffReading(self, entity_id):
+    def get_tarrif_information(self, entity_id):
         if self._tariff_type == NO_TARIFF_INFO:
             return None
         elif self._tariff_type == FIXED_NUMERICAL_TARIFFS:
@@ -409,7 +412,7 @@ class SimulatedBatteryHandle:
 
         return float(self._hass.states.get(entity_id).state)
     
-    def updateBattery(self, import_amount, export_amount):
+    def update_battery(self, import_amount, export_amount):
         _LOGGER.debug(
             "(%s) Battery update event: Import = %s, Export = %s",
             self._name,
@@ -436,7 +439,7 @@ class SimulatedBatteryHandle:
         )
         
         if not any(self._switches.values()):
-            _LOGGER.debug("Battery (%s) normal mode.", self._name)
+            _LOGGER.debug("(%s) Battery normal mode.", self._name)
             amount_to_charge = min(
                 export_amount, max_charge, available_capacity_to_charge
             )
@@ -451,7 +454,7 @@ class SimulatedBatteryHandle:
                 self._sensors[BATTERY_MODE] = MODE_DISCHARGING
 
         if self._switches[PAUSE_BATTERY]:
-            _LOGGER.debug("Battery (%s) paused.", self._name)
+            _LOGGER.debug("(%s) Battery paused.", self._name)
             amount_to_charge = 0.0
             amount_to_discharge = 0.0
             net_export = export_amount
@@ -459,7 +462,7 @@ class SimulatedBatteryHandle:
             self._sensors[BATTERY_MODE] = MODE_IDLE
             
         if self._switches[OVERIDE_CHARGING]:
-            _LOGGER.debug("Battery (%s) overide charging.", self._name)
+            _LOGGER.debug("(%s) Battery overide charging.", self._name)
             amount_to_charge = min(max_charge, available_capacity_to_charge)
             amount_to_discharge = 0.0
             net_export = max(export_amount - amount_to_charge, 0)
@@ -468,7 +471,7 @@ class SimulatedBatteryHandle:
             self._sensors[BATTERY_MODE] = MODE_FORCE_CHARGING
             
         if self._switches[FORCE_DISCHARGE]:
-            _LOGGER.debug("Battery (%s) forced discharging.", self._name)
+            _LOGGER.debug("(%s) Battery forced discharging.", self._name)
             amount_to_charge = 0.0
             amount_to_discharge = min(max_discharge, available_capacity_to_discharge)
             net_export = max(amount_to_discharge - import_amount, 0) + export_amount
@@ -476,7 +479,7 @@ class SimulatedBatteryHandle:
             self._sensors[BATTERY_MODE] = MODE_FORCE_DISCHARGING
             
         if self._switches[CHARGE_ONLY]:
-            _LOGGER.debug("Battery (%s) charge only mode.", self._name)
+            _LOGGER.debug("(%s) Battery charge only mode.", self._name)
             amount_to_charge: float = min(
                 export_amount, max_charge, available_capacity_to_charge
             )
@@ -488,8 +491,8 @@ class SimulatedBatteryHandle:
             else:
                 self._sensors[BATTERY_MODE] = MODE_IDLE
 
-        current_import_tariff = self.getTariffReading(self._import_tariff_sensor_id)
-        current_export_tariff = self.getTariffReading(self._export_tariff_sensor_id)
+        current_import_tariff = self.get_tarrif_information(self._import_tariff_sensor_id)
+        current_export_tariff = self.get_tarrif_information(self._export_tariff_sensor_id)
 
         if current_import_tariff is not None:
             self._sensors[ATTR_MONEY_SAVED_IMPORT] += (
@@ -512,10 +515,16 @@ class SimulatedBatteryHandle:
         )
 
         self._sensors[ATTR_ENERGY_SAVED] += import_amount - net_import
+        
+        #BUG: GRID Import / Export start at 0.
         self._sensors[GRID_IMPORT_SIM] += net_import
         self._sensors[GRID_EXPORT_SIM] += net_export
         self._sensors[ATTR_ENERGY_BATTERY_IN] += amount_to_charge
         self._sensors[ATTR_ENERGY_BATTERY_OUT] += amount_to_discharge
+        
+        #BUG: Charging Rate = 8 kWh (at setting with 8 kWh) but this isn't correct. 
+        #       - PV can max output 5kWh
+        #       - Check calculation.
         self._sensors[CHARGING_RATE] = amount_to_charge / (
             time_since_last_battery_update / 3600
         )
@@ -550,168 +559,5 @@ class SimulatedBatteryHandle:
         self._last_battery_update_time = time_now
         dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
         _LOGGER.debug(
-            "Battery update complete (%s). Sensors: %s", self._name, self._sensors
+            "(%s) Battery update complete. Sensors: %s", self._name, self._sensors
         )
-
-    # def updateBattery(self, import_amount, export_amount):
-    #     _LOGGER.debug(
-    #         "Battery update event (%s). Import: %s, Export: %s",
-    #         self._name,
-    #         round(import_amount, 4),
-    #         round(export_amount, 4),
-    #     )
-
-    #     def calculate_charge_discharge(
-    #         is_charge, max_rate, available_capacity, reading_amount
-    #     ):
-    #         if is_charge:
-    #             return min(reading_amount, max_rate, available_capacity)
-    #         else:
-    #             return min(reading_amount, max_rate, available_capacity) / float(
-    #                 self._battery_efficiency
-    #             )
-        
-    #     if self._charge_state == "unknown":
-    #         self._charge_state = 0.0
-
-    #     time_now = time.time()
-        
-    #     time_since_last_battery_update = time_now - self._last_battery_update_time
-        
-    #     _LOGGER.debug(f"Last Update: {self._last_battery_update_time} - Now: {time_now} = {time_since_last_battery_update}")
-        
-    #     max_discharge = time_since_last_battery_update * self._max_discharge_rate / 3600
-    #     max_charge = time_since_last_battery_update * self._max_charge_rate / 3600
-        
-    #     current_import_tariff = self.getTariffReading(self._import_tariff_sensor_id)
-    #     current_export_tariff = self.getTariffReading(self._export_tariff_sensor_id)
-    
-    #     is_charge = self._switches[OVERIDE_CHARGING]
-    #     is_discharge = self._switches[FORCE_DISCHARGE]
-    #     is_charge_only = self._switches[CHARGE_ONLY]    
-    #     is_paused = self._switches[PAUSE_BATTERY]
-        
-    #     _LOGGER.debug("Battery (%s): Is Force Charging: %s ", self._name, is_charge)
-    #     _LOGGER.debug("Battery (%s): Is Force Discharging: %s ", self._name,  is_discharge)
-    #     _LOGGER.debug("Battery (%s): Is Charge Only: %s", self._name,  is_charge_only)
-    #     _LOGGER.debug("Battery (%s): Is Paused: %s", self._name,  is_paused)
-        
-    #     _LOGGER.debug("Battery (%s): %s", self._name, self._sensors)
-
-    #     if is_paused:          
-    #         self._sensors[BATTERY_MODE] = MODE_IDLE
-    #         self._sensors[GRID_IMPORT_SIM] += import_amount
-    #         self._sensors[GRID_EXPORT_SIM] += export_amount
-    #         self._sensors[ATTR_ENERGY_BATTERY_IN] += 0.0
-    #         self._sensors[ATTR_ENERGY_BATTERY_OUT] += 0.0
-    #         self._sensors[CHARGING_RATE] = 0.0 
-    #         self._sensors[DISCHARGING_RATE] = 0.0 
-
-    #     else:
-    #         if self._sensors[CHARGING_RATE] <= 0:
-    #             self._sensors[BATTERY_MODE] = MODE_EMPTY
-            
-    #         amount_to_charge = calculate_charge_discharge(
-    #             is_charge,
-    #             max_charge,
-    #             self._battery_size - float(self._charge_state),
-    #             export_amount,
-    #         )
-
-    #         amount_to_discharge = calculate_charge_discharge(
-    #             is_discharge,
-    #             max_discharge,
-    #             float(self._charge_state) * float(self._battery_efficiency),
-    #             import_amount,
-    #         )
-            
-    #         _LOGGER.debug(
-    #             "Battery update event (%s). Amount to Charge: %s, Amount to Discharge: %s",
-    #             self._name,
-    #             round(amount_to_charge, 4),
-    #             round(amount_to_discharge, 4),
-    #         )
-
-    #         net_export = max(amount_to_discharge - import_amount, 0) + export_amount
-    #         net_import = max(import_amount - amount_to_discharge, 0)
-            
-    #         _LOGGER.debug(
-    #             "Battery update event (%s). Net Import: %s, Net Export: %s",
-    #             self._name,
-    #             round(net_import, 4),
-    #             round(net_export, 4),
-    #         )
-
-    #         if is_charge_only:
-    #             self._sensors[BATTERY_MODE] = (
-    #                 MODE_CHARGING
-    #                 if amount_to_charge > amount_to_discharge
-    #                 else MODE_IDLE
-    #             )
-    #         else:
-    #             self._sensors[BATTERY_MODE] = (
-    #                 MODE_CHARGING
-    #                 if amount_to_charge > amount_to_discharge
-    #                 else MODE_DISCHARGING
-    #             )
-
-    #         if current_import_tariff is not None:
-    #             self._sensors[ATTR_MONEY_SAVED_IMPORT] += (
-    #                 import_amount - net_import
-    #             ) * current_import_tariff
-    #         if current_export_tariff is not None:
-    #             self._sensors[ATTR_MONEY_SAVED_EXPORT] += (
-    #                 net_export - export_amount
-    #             ) * current_export_tariff
-
-    #         if self._tariff_type is not NO_TARIFF_INFO:
-    #             self._sensors[ATTR_MONEY_SAVED] = (
-    #                 self._sensors[ATTR_MONEY_SAVED_IMPORT]
-    #                 + self._sensors[ATTR_MONEY_SAVED_EXPORT]
-    #             )
-
-    #         self._charge_state += amount_to_charge - amount_to_discharge
-
-    #         self._sensors[ATTR_ENERGY_SAVED] += import_amount - net_import
-    #         self._sensors[GRID_IMPORT_SIM] += net_import
-    #         self._sensors[GRID_EXPORT_SIM] += net_export
-    #         self._sensors[ATTR_ENERGY_BATTERY_IN] += amount_to_charge
-    #         self._sensors[ATTR_ENERGY_BATTERY_OUT] += amount_to_discharge
-
-    #         self._sensors[CHARGING_RATE] = amount_to_charge / (
-    #             time_since_last_battery_update / 3600
-    #         )
-    #         self._sensors[DISCHARGING_RATE] = amount_to_discharge / (
-    #             time_since_last_battery_update / 3600
-    #         )
-    #         self._sensors[BATTERY_CYCLES] = (
-    #             self._sensors[ATTR_ENERGY_BATTERY_IN] / self._battery_size
-    #         )
-
-    #         self._charge_percentage = round(100 * self._charge_state / self._battery_size)
-            
-    #         _LOGGER.debug(f"Battery State ({self._name}): {self._charge_percentage}% ")
-
-    #         if self._charge_percentage < 2:
-    #             self._sensors[BATTERY_MODE] = MODE_EMPTY
-    #         elif self._charge_percentage > 98:
-    #             self._sensors[BATTERY_MODE] = MODE_FULL
-                
-    #         _LOGGER.debug(f"Battery State ({self._name}): {self._charge_percentage}% @ {self._sensors[BATTERY_MODE]} ")
-            
-    #         last_update_battery = self._last_battery_update_time
-
-    #         # if last_update_battery.weekday() != time_now.weekday():
-    #         #     self._energy_saved_today = 0
-    #         # if last_update_battery.isocalendar()[1] != time_now.isocalendar()[1]:
-    #         #     self._energy_saved_week = 0
-    #         # if last_update_battery.month != time_now.month:
-    #         #     self._energy_saved_month = 0
-                
-    #         self._last_battery_update_time = time_now
-
-    #     _LOGGER.debug(
-    #         "Battery update complete (%s). Sensors: %s", self._name, self._sensors
-    #     )
-
-    #     dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -49,8 +49,6 @@ from .const import (
     MODE_IDLE,
     MODE_CHARGING,
     MODE_DISCHARGING,
-    MODE_FORCE_CHARGING,
-    MODE_FORCE_DISCHARGING,
     MODE_FULL,
     MODE_EMPTY,
     ATTR_MONEY_SAVED_IMPORT,
@@ -60,6 +58,9 @@ from .const import (
     TARIFF_SENSOR_ENTITIES,
     FIXED_NUMERICAL_TARIFFS,
     BATTERY_CYCLES,
+    MESSAGE_TYPE_GENERAL,
+    MESSAGE_TYPE_BATTERY_RESET,
+    MESSAGE_TYPE_BATTERY_UPDATE,
     CHARGE_ONLY,
 )
 
@@ -91,7 +92,7 @@ async def async_setup(hass, config):
     """Set up battery platforms from a YAML."""
     hass.data.setdefault(DOMAIN, {})
 
-    if config.get(DOMAIN) == None:
+    if config.get(DOMAIN) is None:
         return True
     for battery, conf in config.get(DOMAIN).items():
         _LOGGER.debug("Setup %s.%s", DOMAIN, battery)
@@ -138,55 +139,65 @@ class SimulatedBatteryHandle:
         self._hass = hass
         self._import_sensor_id = config[CONF_IMPORT_SENSOR]
         self._export_sensor_id = config[CONF_EXPORT_SENSOR]
-        self._second_import_sensor_id = None
-        self._second_export_sensor_id = None
-        if (
-            CONF_SECOND_IMPORT_SENSOR in config
-            and len(config[CONF_SECOND_IMPORT_SENSOR]) > 6
-        ):
-            self._second_import_sensor_id = config[CONF_SECOND_IMPORT_SENSOR]
-        if (
-            CONF_SECOND_EXPORT_SENSOR in config
-            and len(config[CONF_SECOND_EXPORT_SENSOR]) > 6
-        ):
-            self._second_export_sensor_id = config[CONF_SECOND_EXPORT_SENSOR]
+
+        self._second_import_sensor_id = (
+            config.get(CONF_SECOND_IMPORT_SENSOR)
+            if len(config.get(CONF_SECOND_IMPORT_SENSOR, "")) > 6
+            else None
+        )
+
+        self._second_export_sensor_id = (
+            config.get(CONF_SECOND_EXPORT_SENSOR)
+            if len(config.get(CONF_SECOND_EXPORT_SENSOR, "")) > 6
+            else None
+        )
+
+        self._second_import_configured = bool(self._second_import_sensor_id)
+        self._second_export_configured = bool(self._second_export_sensor_id)
+
         """Defalt to sensor entites for backwards compatibility"""
         self._tariff_type = TARIFF_SENSOR_ENTITIES
         if TARIFF_TYPE in config:
             self._tariff_type = config[TARIFF_TYPE]
+
         self._import_tariff_sensor_id = None
         if CONF_ENERGY_IMPORT_TARIFF in config:
             self._import_tariff_sensor_id = config[CONF_ENERGY_IMPORT_TARIFF]
         elif CONF_ENERGY_TARIFF in config:
             """For backwards compatibility"""
             self._import_tariff_sensor_id = config[CONF_ENERGY_TARIFF]
+
         self._export_tariff_sensor_id = None
         if CONF_ENERGY_EXPORT_TARIFF in config:
             self._export_tariff_sensor_id = config[CONF_ENERGY_EXPORT_TARIFF]
+
         self._date_recording_started = time.asctime()
-        self._collecting1 = None
-        self._collecting2 = None
-        self._collecting3 = None
+        self._sensor_collection = []
         self._charging = False
+
         self._name = config[CONF_NAME]
         self._battery_size = config[CONF_BATTERY_SIZE]
         self._max_discharge_rate = config[CONF_BATTERY_MAX_DISCHARGE_RATE]
         self._max_charge_rate = config[CONF_BATTERY_MAX_CHARGE_RATE]
         self._battery_efficiency = config[CONF_BATTERY_EFFICIENCY]
+
         self._last_import_reading_time = time.time()
         self._last_export_reading_time = time.time()
         self._last_battery_update_time = time.time()
+
         self._max_discharge = 0.0
         self._charge_percentage = 0.0
         self._charge_state = 0.0
         self._last_export_reading = 0.0
         self._last_import_cumulative_reading = 1.0
+
         self._switches = {
             OVERIDE_CHARGING: False,
             PAUSE_BATTERY: False,
             FORCE_DISCHARGE: False,
             CHARGE_ONLY: False,
         }
+
         self._sensors = {
             ATTR_ENERGY_SAVED: 0.0,
             ATTR_ENERGY_BATTERY_OUT: 0.0,
@@ -203,188 +214,186 @@ class SimulatedBatteryHandle:
         }
 
         async_at_start(self._hass, self.async_source_tracking)
+
         async_dispatcher_connect(
-            self._hass, f"{self._name}-BatteryResetMessage", self.async_reset_battery
+            self._hass, 
+            f"{self._name}-{MESSAGE_TYPE_GENERAL}", 
+            self.async_reset_battery
         )
+
         async_dispatcher_connect(
             self._hass,
-            f"{self._name}-BatteryResetImportSim",
-            self.reset_import_sim_sensor,
+            f"{self._name}-{MESSAGE_TYPE_BATTERY_RESET}",
+            self.reset_sim_sensor,
         )
+        
         async_dispatcher_connect(
-            self._hass,
-            f"{self._name}-BatteryResetExportSim",
-            self.reset_export_sim_sensor,
+            self._hass, 
+            f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}",
+            self.updateBattery
         )
 
     def async_reset_battery(self):
         _LOGGER.debug("Reset battery")
-        self.reset_import_sim_sensor()
-        self.reset_export_sim_sensor()
+        self.reset_sim_sensor(
+            GRID_IMPORT_SIM, self._import_sensor_id, self._second_import_sensor_id
+        )
+        self.reset_sim_sensor(
+            GRID_EXPORT_SIM, self._export_sensor_id, self._second_export_sensor_id
+        )
+
         self._charge_state = 0.0
+
         self._sensors[ATTR_ENERGY_SAVED] = 0.0
         self._sensors[ATTR_MONEY_SAVED] = 0.0
         self._sensors[ATTR_ENERGY_BATTERY_OUT] = 0.0
         self._sensors[ATTR_ENERGY_BATTERY_IN] = 0.0
         self._sensors[ATTR_MONEY_SAVED_IMPORT] = 0.0
         self._sensors[ATTR_MONEY_SAVED_EXPORT] = 0.0
+
         self._energy_saved_today = 0.0
         self._energy_saved_week = 0.0
         self._energy_saved_month = 0.0
+
         self._date_recording_started = time.asctime()
-        dispatcher_send(self._hass, f"{self._name}-BatteryUpdateMessage")
-        return
+        dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
 
-    def reset_import_sim_sensor(self):
-        _LOGGER.debug("Reset import sim sensor")
-        if self._hass.states.get(
-            self._import_sensor_id
-        ).state is not None and self._hass.states.get(
-            self._import_sensor_id
-        ).state not in [
-            STATE_UNAVAILABLE,
-            STATE_UNKNOWN,
-        ]:
-            self._sensors[GRID_IMPORT_SIM] = float(
-                self._hass.states.get(self._import_sensor_id).state
-            )
-        else:
-            self._sensors[GRID_IMPORT_SIM] = 0.0
-        dispatcher_send(self._hass, f"{self._name}-BatteryUpdateMessage")
+    def reset_sim_sensor(
+        self, target_sensor_key, primary_sensor_id, secondary_sensor_id
+    ):
+        _LOGGER.debug(f"Reset {target_sensor_key} sim sensor")
 
-    def reset_export_sim_sensor(self):
-        _LOGGER.debug("Reset export sim sensor")
-        if self._hass.states.get(
-            self._export_sensor_id
-        ).state is not None and self._hass.states.get(
-            self._export_sensor_id
-        ).state not in [
-            STATE_UNAVAILABLE,
-            STATE_UNKNOWN,
-        ]:
-            self._sensors[GRID_EXPORT_SIM] = float(
-                self._hass.states.get(self._export_sensor_id).state
-            )
-        else:
-            self._sensors[GRID_EXPORT_SIM] = 0.0
-        dispatcher_send(self._hass, f"{self._name}-BatteryUpdateMessage")
+        sensor_ids = [primary_sensor_id]
+
+        if secondary_sensor_id is not None:
+            sensor_ids.append(secondary_sensor_id)
+
+        total_sim = sum(
+            float(self._hass.states.get(sid).state or 0.0)
+            for sid in sensor_ids
+            if self._hass.states.get(sid).state
+            not in [STATE_UNAVAILABLE, STATE_UNKNOWN]
+        )
+
+        self._sensors[target_sensor_key] = total_sim
+        dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
 
     @callback
     def async_source_tracking(self, event):
-        """Wait for source to be ready, then start."""
-        self._collecting1 = async_track_state_change_event(
-            self._hass, [self._import_sensor_id], self.async_import_reading
-        )
-        _LOGGER.debug("<%s> monitoring %s", self._name, self._import_sensor_id)
-        if self._second_import_sensor_id != None:
-            self._collecting3 = async_track_state_change_event(
-                self._hass, [self._second_import_sensor_id], self.async_import_reading
+        """Wait for sources to be ready, then start tracking."""
+
+        def start_sensor_tracking(sensor_id, reading_function, is_import):
+            """Start tracking state changes for a sensor."""
+            self._sensor_collection.append(
+                async_track_state_change_event(
+                    self._hass,
+                    [sensor_id],
+                    lambda event: reading_function(event, is_import),
+                )
             )
-        _LOGGER.debug("<%s> monitoring %s", self._name, self._second_import_sensor_id)
-        self._collecting2 = async_track_state_change_event(
-            self._hass, [self._export_sensor_id], self.async_export_reading
+            _LOGGER.debug("<%s> monitoring %s", self._name, sensor_id)
+
+        start_sensor_tracking(
+            self._import_sensor_id, self.async_reading_handler, is_import=True
         )
-        _LOGGER.debug("<%s> monitoring %s", self._name, self._export_sensor_id)
-        if self._second_export_sensor_id != None:
-            self._collecting4 = async_track_state_change_event(
-                self._hass, [self._second_export_sensor_id], self.async_export_reading
+        start_sensor_tracking(
+            self._export_sensor_id, self.async_reading_handler, is_import=False
+        )
+
+        if self._second_import_sensor_id is not None:
+            start_sensor_tracking(
+                self._second_import_sensor_id,
+                self.async_reading_handler,
+                is_import=True,
             )
-        _LOGGER.debug("<%s> monitoring %s", self._name, self._second_export_sensor_id)
+
+        if self._second_export_sensor_id is not None:
+            start_sensor_tracking(
+                self._second_export_sensor_id,
+                self.async_reading_handler,
+                is_import=False,
+            )
+
+        _LOGGER.debug(
+            "<%s> monitoring %s", self._name, "Done adding the Sensor tracking ... "
+        )
 
     @callback
-    def async_export_reading(self, event):
-        """Handle the source entity state changes."""
+    def async_reading_handler(self, event, is_import):
+        """Handle the sensor state changes for import or export."""
+        sensor_id = self._import_sensor_id if is_import else self._export_sensor_id
+        sensor_type = "import" if is_import else "export"
+        sensor_charge_rate = DISCHARGING_RATE if is_import else CHARGING_RATE
+
+        cumulative_reading_attr = f"_last_{sensor_type}_cumulative_reading"
+        last_reading_time_attr = f"_last_{sensor_type}_reading_time"
+        last_reading_attr = f"_last_{sensor_type}_reading"
+
         old_state = event.data.get("old_state")
         new_state = event.data.get("new_state")
-        if (
-            old_state is None
-            or new_state is None
-            or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-            or new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-        ):
+
+        if not (old_state and new_state):
             return
 
-        units = self._hass.states.get(self._export_sensor_id).attributes.get(
+        units = self._hass.states.get(sensor_id).attributes.get(
             ATTR_UNIT_OF_MEASUREMENT
         )
+
         if units not in [UnitOfEnergy.KILO_WATT_HOUR, UnitOfEnergy.WATT_HOUR]:
             _LOGGER.warning(
-                "Units of import sensor not recognised - may give wrong results"
+                "Units of %s sensor not recognized - may give wrong results",
+                sensor_type,
             )
-        conversion_factor = 1.0
-        if units == UnitOfEnergy.WATT_HOUR:
-            conversion_factor = 0.001
 
-        export_amount = conversion_factor * (
-            float(new_state.state) - float(old_state.state)
-        )
+        conversion_factor = 1.0 if units == UnitOfEnergy.KILO_WATT_HOUR else 0.001
 
-        if export_amount < 0:
-            _LOGGER.warning("Export sensor value decreased - meter may have been reset")
-            self._sensors[CHARGING_RATE] = 0
-            self._last_export_reading_time = time.time()
+        old_state_value = float(old_state.state)
+        new_state_value = float(new_state.state)
+
+        reading_difference = new_state_value - old_state_value
+
+        if reading_difference < 0:
+            _LOGGER.warning(
+                "%s sensor value decreased - meter may have been reset",
+                sensor_type,
+            )
+            self._sensors[sensor_charge_rate] = 0
             return
+
+        last_reading = getattr(self, last_reading_attr)
+
+        setattr(self, last_reading_time_attr, time.time())
+
+        cumulative_reading = conversion_factor * new_state_value
+        rate_reading = conversion_factor * reading_difference
 
         if self._last_import_reading_time > self._last_export_reading_time:
             if self._last_export_reading > 0:
-                _LOGGER.warning("Accumulated export reading not cleared error")
-            self._last_export_reading = export_amount
-        else:
-            export_amount += self._last_export_reading
-            self._last_export_reading = 0.0
-            self.updateBattery(0.0, export_amount)
-        self._last_export_reading_time = time.time()
-
-    @callback
-    def async_import_reading(self, event):
-        """Handle the import sensor state changes - energy being imported from grid to be drawn from battery instead"""
-        old_state = event.data.get("old_state")
-        new_state = event.data.get("new_state")
-
-        """If data missing return"""
-        if (
-            old_state is None
-            or new_state is None
-            or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-            or new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-        ):
-            return
-
-        self._last_import_reading_time = time.time()
-
-        """Check units of import sensor and calculate import amount in kWh"""
-        units = self._hass.states.get(self._import_sensor_id).attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT
-        )
-        if units not in [UnitOfEnergy.KILO_WATT_HOUR, UnitOfEnergy.WATT_HOUR]:
-            _LOGGER.warning(
-                "Units of import sensor not recognised - may give wrong results"
+                _LOGGER.warning("Accumulated reading not cleared error")
+                
+            last_reading = rate_reading
+            
+            _LOGGER.debug(
+                f"Last Reading Time {self._last_import_reading_time} - {self._last_export_reading_time}"
             )
-        conversion_factor = 1.0
-        if units == UnitOfEnergy.WATT_HOUR:
-            conversion_factor = 0.001
+            
+        else:
+            last_reading += rate_reading
+            import_amount = last_reading if is_import else 0.0
+            export_amount = 0.0 if is_import else last_reading
+            self.updateBattery(import_amount, export_amount)
 
-        import_amount = conversion_factor * (
-            float(new_state.state) - float(old_state.state)
-        )
-        self._last_import_cumulative_reading = conversion_factor * (
-            float(new_state.state)
-        )
-
-        if import_amount < 0:
-            _LOGGER.warning("Import sensor value decreased - meter may have been reset")
-            self._sensors[DISCHARGING_RATE] = 0
-            return
-
-        self.updateBattery(import_amount, self._last_export_reading)
-        self._last_export_reading = 0.0
+        setattr(self, cumulative_reading_attr, cumulative_reading)
+        setattr(self, sensor_charge_rate, rate_reading)
+        setattr(self, last_reading_attr, last_reading)
 
     def getTariffReading(self, entity_id):
         if self._tariff_type == NO_TARIFF_INFO:
             return None
         elif self._tariff_type == FIXED_NUMERICAL_TARIFFS:
             return entity_id
-        """Default behaviour - assume sensor entities"""
+
+        # Default behavior - assume sensor entities
         if (
             entity_id is None
             or len(entity_id) < 6
@@ -393,6 +402,7 @@ class SimulatedBatteryHandle:
             in [STATE_UNAVAILABLE, STATE_UNKNOWN]
         ):
             return None
+
         return float(self._hass.states.get(entity_id).state)
 
     def updateBattery(self, import_amount, export_amount):
@@ -402,129 +412,146 @@ class SimulatedBatteryHandle:
             round(import_amount, 4),
             round(export_amount, 4),
         )
+
+        def calculate_charge_discharge(
+            is_charge, max_rate, available_capacity, reading_amount
+        ):
+            if is_charge:
+                return min(reading_amount, max_rate, available_capacity)
+            else:
+                return min(reading_amount, max_rate, available_capacity) / float(
+                    self._battery_efficiency
+                )
+        
         if self._charge_state == "unknown":
             self._charge_state = 0.0
 
-        """Calculate maximum possible charge and discharge based on battery specifications and time since last discharge"""
         time_now = time.time()
         time_since_last_battery_update = time_now - self._last_battery_update_time
         max_discharge = time_since_last_battery_update * self._max_discharge_rate / 3600
         max_charge = time_since_last_battery_update * self._max_charge_rate / 3600
-        available_capacity_to_charge = self._battery_size - float(self._charge_state)
-        available_capacity_to_discharge = float(self._charge_state) * float(
-            self._battery_efficiency
-        )
-
-        if self._switches[PAUSE_BATTERY]:
-            _LOGGER.debug("Battery (%s) paused.", self._name)
-            amount_to_charge = 0.0
-            amount_to_discharge = 0.0
-            net_export = export_amount
-            net_import = import_amount
-            self._sensors[BATTERY_MODE] = MODE_IDLE
-        elif self._switches[OVERIDE_CHARGING]:
-            _LOGGER.debug("Battery (%s) overide charging.", self._name)
-            amount_to_charge = min(max_charge, available_capacity_to_charge)
-            amount_to_discharge = 0.0
-            net_export = max(export_amount - amount_to_charge, 0)
-            net_import = max(amount_to_charge - export_amount, 0) + import_amount
-            self._charging = True
-            self._sensors[BATTERY_MODE] = MODE_FORCE_CHARGING
-        elif self._switches[FORCE_DISCHARGE]:
-            _LOGGER.debug("Battery (%s) forced discharging.", self._name)
-            amount_to_charge = 0.0
-            amount_to_discharge = min(max_discharge, available_capacity_to_discharge)
-            net_export = max(amount_to_discharge - import_amount, 0) + export_amount
-            net_import = max(import_amount - amount_to_discharge, 0)
-            self._sensors[BATTERY_MODE] = MODE_FORCE_DISCHARGING
-        elif self._switches[CHARGE_ONLY]:
-            _LOGGER.debug("Battery (%s) charge only mode.", self._name)
-            amount_to_charge = min(
-                export_amount, max_charge, available_capacity_to_charge
-            )
-            amount_to_discharge = 0.0
-            net_import = import_amount
-            net_export = export_amount - amount_to_charge
-            if amount_to_charge > amount_to_discharge:
-                self._sensors[BATTERY_MODE] = MODE_CHARGING
-            else:
-                self._sensors[BATTERY_MODE] = MODE_IDLE
-        else:
-            _LOGGER.debug("Battery (%s) normal mode.", self._name)
-            amount_to_charge = min(
-                export_amount, max_charge, available_capacity_to_charge
-            )
-            amount_to_discharge = min(
-                import_amount, max_discharge, available_capacity_to_discharge
-            )
-            net_import = import_amount - amount_to_discharge
-            net_export = export_amount - amount_to_charge
-            if amount_to_charge > amount_to_discharge:
-                self._sensors[BATTERY_MODE] = MODE_CHARGING
-            else:
-                self._sensors[BATTERY_MODE] = MODE_DISCHARGING
-
+        
         current_import_tariff = self.getTariffReading(self._import_tariff_sensor_id)
         current_export_tariff = self.getTariffReading(self._export_tariff_sensor_id)
+    
+        is_charge = self._switches[OVERIDE_CHARGING]
+        is_discharge = self._switches[FORCE_DISCHARGE]
+        is_charge_only = self._switches[CHARGE_ONLY]    
+        is_paused = self._switches[PAUSE_BATTERY]
+        
+        _LOGGER.debug("Battery (%s) Settings.", self._name)
+        _LOGGER.debug("Is Force Charging: ", is_charge)
+        _LOGGER.debug("Is Force Discharging: ", is_discharge)
+        _LOGGER.debug("Is Charge Only: ", is_charge_only)
+        _LOGGER.debug("Is Paused: ", is_paused)
 
-        if current_import_tariff is not None:
-            self._sensors[ATTR_MONEY_SAVED_IMPORT] += (
-                import_amount - net_import
-            ) * current_import_tariff
-        if current_export_tariff is not None:
-            self._sensors[ATTR_MONEY_SAVED_EXPORT] += (
-                net_export - export_amount
-            ) * current_export_tariff
-        if self._tariff_type is not NO_TARIFF_INFO:
-            self._sensors[ATTR_MONEY_SAVED] = (
-                self._sensors[ATTR_MONEY_SAVED_IMPORT]
-                + self._sensors[ATTR_MONEY_SAVED_EXPORT]
+        if is_paused:
+            _LOGGER.debug("Battery (%s) paused.", self._name)
+           
+            self._sensors[BATTERY_MODE] = MODE_IDLE
+            self._sensors[GRID_IMPORT_SIM] += import_amount
+            self._sensors[GRID_EXPORT_SIM] += export_amount
+            self._sensors[ATTR_ENERGY_BATTERY_IN] += 0.0
+            self._sensors[ATTR_ENERGY_BATTERY_OUT] += 0.0
+            self._sensors[CHARGING_RATE] = 0.0 
+            self._sensors[DISCHARGING_RATE] = 0.0 
+
+        else:
+            amount_to_charge = calculate_charge_discharge(
+                is_charge,
+                max_charge,
+                self._battery_size - float(self._charge_state),
+                export_amount,
             )
 
-        self._charge_state = (
-            float(self._charge_state)
-            + amount_to_charge
-            - (amount_to_discharge / float(self._battery_efficiency))
-        )
+            amount_to_discharge = calculate_charge_discharge(
+                is_discharge,
+                max_discharge,
+                float(self._charge_state) * float(self._battery_efficiency),
+                import_amount,
+            )
+            
+            _LOGGER.debug(
+                "Battery update event (%s). Amount to Charge: %s, Amount to Discharge: %s",
+                self._name,
+                round(amount_to_charge, 4),
+                round(amount_to_discharge, 4),
+            )
 
-        self._sensors[ATTR_ENERGY_SAVED] += import_amount - net_import
-        self._sensors[GRID_IMPORT_SIM] += net_import
-        self._sensors[GRID_EXPORT_SIM] += net_export
-        self._sensors[ATTR_ENERGY_BATTERY_IN] += amount_to_charge
-        self._sensors[ATTR_ENERGY_BATTERY_OUT] += amount_to_discharge
-        self._sensors[CHARGING_RATE] = amount_to_charge / (
-            time_since_last_battery_update / 3600
-        )
-        self._sensors[DISCHARGING_RATE] = amount_to_discharge / (
-            time_since_last_battery_update / 3600
-        )
-        self._sensors[BATTERY_CYCLES] = (
-            self._sensors[ATTR_ENERGY_BATTERY_IN] / self._battery_size
-        )
+            net_export = max(amount_to_discharge - import_amount, 0) + export_amount
+            net_import = max(import_amount - amount_to_discharge, 0)
+            
+            _LOGGER.debug(
+                "Battery update event (%s). Net Import: %s, Net Export: %s",
+                self._name,
+                round(net_import, 4),
+                round(net_export, 4),
+            )
 
-        self._charge_percentage = round(100 * self._charge_state / self._battery_size)
+            if is_charge_only:
+                self._sensors[BATTERY_MODE] = (
+                    MODE_CHARGING
+                    if amount_to_charge > amount_to_discharge
+                    else MODE_IDLE
+                )
+            else:
+                self._sensors[BATTERY_MODE] = (
+                    MODE_CHARGING
+                    if amount_to_charge > amount_to_discharge
+                    else MODE_DISCHARGING
+                )
 
-        if self._charge_percentage < 2:
-            self._sensors[BATTERY_MODE] = MODE_EMPTY
-        elif self._charge_percentage > 98:
-            self._sensors[BATTERY_MODE] = MODE_FULL
+            if current_import_tariff is not None:
+                self._sensors[ATTR_MONEY_SAVED_IMPORT] += (
+                    import_amount - net_import
+                ) * current_import_tariff
+            if current_export_tariff is not None:
+                self._sensors[ATTR_MONEY_SAVED_EXPORT] += (
+                    net_export - export_amount
+                ) * current_export_tariff
 
-        """Reset day/week/month counters"""
-        if time.strftime("%w") != time.strftime(
-            "%w", time.gmtime(self._last_battery_update_time)
-        ):
-            self._energy_saved_today = 0
-        if time.strftime("%U") != time.strftime(
-            "%U", time.gmtime(self._last_battery_update_time)
-        ):
-            self._energy_saved_week = 0
-        if time.strftime("%m") != time.strftime(
-            "%m", time.gmtime(self._last_battery_update_time)
-        ):
-            self._energy_saved_month = 0
+            if self._tariff_type is not NO_TARIFF_INFO:
+                self._sensors[ATTR_MONEY_SAVED] = (
+                    self._sensors[ATTR_MONEY_SAVED_IMPORT]
+                    + self._sensors[ATTR_MONEY_SAVED_EXPORT]
+                )
 
-        self._last_battery_update_time = time_now
-        dispatcher_send(self._hass, f"{self._name}-BatteryUpdateMessage")
+            self._charge_state += amount_to_charge - amount_to_discharge
+
+            self._sensors[ATTR_ENERGY_SAVED] += import_amount - net_import
+            self._sensors[GRID_IMPORT_SIM] += net_import
+            self._sensors[GRID_EXPORT_SIM] += net_export
+            self._sensors[ATTR_ENERGY_BATTERY_IN] += amount_to_charge
+            self._sensors[ATTR_ENERGY_BATTERY_OUT] += amount_to_discharge
+
+            self._sensors[CHARGING_RATE] = amount_to_charge / (
+                time_since_last_battery_update / 3600
+            )
+            self._sensors[DISCHARGING_RATE] = amount_to_discharge / (
+                time_since_last_battery_update / 3600
+            )
+            self._sensors[BATTERY_CYCLES] = (
+                self._sensors[ATTR_ENERGY_BATTERY_IN] / self._battery_size
+            )
+
+            self._charge_percentage = round(100 * self._charge_state / self._battery_size)
+
+            if self._charge_percentage < 2:
+                self._sensors[BATTERY_MODE] = MODE_EMPTY
+            elif self._charge_percentage > 98:
+                self._sensors[BATTERY_MODE] = MODE_FULL
+
+            if self._last_battery_update_time.weekday() != time_now.weekday():
+                self._energy_saved_today = 0
+            if self._last_battery_update_time.isocalendar()[1] != time_now.isocalendar()[1]:
+                self._energy_saved_week = 0
+            if self._last_battery_update_time.month != time_now.month:
+                self._energy_saved_month = 0
+
+            self._last_battery_update_time = time_now
+
         _LOGGER.debug(
             "Battery update complete (%s). Sensors: %s", self._name, self._sensors
         )
+
+        dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -190,7 +190,7 @@ class SimulatedBatteryHandle:
         self._second_import_configured: bool = bool(self._second_import_sensor_id)
         self._second_export_configured: bool = bool(self._second_export_sensor_id)
 
-        """Defalt to sensor entites for backwards compatibility"""
+        """Default sensor entities for backwards compatibility"""
         self._tariff_type: str = TARIFF_SENSOR_ENTITIES
 
         if TARIFF_TYPE in config:

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -305,12 +305,12 @@ class SimulatedBatteryHandle:
                 collection,
                 async_track_state_change_event(
                     self._hass,
-                    [sensor_id], # List, so could there be more?
+                    [sensor_id],
                     lambda event: reading_function(event, is_import),
                 )
             )
             
-            _LOGGER.debug("<%s> monitoring %s", self._name, sensor_id)
+            _LOGGER.debug("(%s) monitoring %s", self._name, sensor_id)
 
         start_sensor_tracking(
             sensor_id = self._import_sensor_id, 
@@ -339,11 +339,11 @@ class SimulatedBatteryHandle:
                 sensor_id = self._second_export_sensor_id, 
                 collection = '_export_collection_secondary',
                 reading_function= self.async_reading_handler, 
-                is_import=True
+                is_import=False
             )  
 
         _LOGGER.debug(
-            "<%s> monitoring %s", self._name, "Done adding the Sensor tracking ... "
+            "(%s) monitoring %s", self._name, "Done adding the Sensor tracking ... "
         )
 
     @callback
@@ -368,30 +368,38 @@ class SimulatedBatteryHandle:
             or new_state is None
             or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
             or new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-            or old_state == new_state
         ):
-            _LOGGER.debug("(%s) No change in readings .. ", self._name)
+            # Incorrect Setup or Sensors are not ready
             return
 
         units = self._hass.states.get(sensor_id).attributes.get(
             ATTR_UNIT_OF_MEASUREMENT
         )
 
+        # TODO: Find logic to determine this once at Initialization
         if units not in [UnitOfEnergy.KILO_WATT_HOUR, UnitOfEnergy.WATT_HOUR]:
             _LOGGER.warning(
                 "Units of %s sensor not recognized - may give wrong results",
                 sensor_type,
             )
 
+        # TODO: Find logic to determine this once at Initialization
         conversion_factor = 1.0 if units == UnitOfEnergy.KILO_WATT_HOUR else 0.001
+        unit_of_energy = 'kWh' if units == UnitOfEnergy.KILO_WATT_HOUR else 'wH'
 
+        # TODO: Find logic to determine this once at Initialization (Conversion factor)
         new_state_value = float(new_state.state) * conversion_factor
         old_state_value = float(old_state.state) * conversion_factor
+
+
+        if new_state_value == old_state_value:
+            # _LOGGER.debug("(%s) No change in readings .. ", self._name)
+            return
 
         reading_variance = new_state_value - old_state_value
 
         _LOGGER.debug(
-            f"({self._name}) {sensor_id}: {old_state_value} => {new_state_value} = {reading_variance}"
+            f"({self._name}) {sensor_id} {is_import}: {old_state_value} {unit_of_energy} => {new_state_value} {unit_of_energy} = Δ {reading_variance} {unit_of_energy}"
         )
 
         if reading_variance < 0:
@@ -462,8 +470,10 @@ class SimulatedBatteryHandle:
         time_since_last_battery_update = time_now - time_last_update
 
         _LOGGER.debug(
-            "(%s) Timing: %s = Now / %s = Last Update / %s Time (sec).",
+            "(%s) Import: (%s) Export: (%s) .... Timing: %s = Now / %s = Last Update / %s Time (sec).",
             self._name,
+            import_amount,
+            export_amount,
             time_now,
             time_last_update,
             time_since_last_battery_update,
@@ -471,29 +481,15 @@ class SimulatedBatteryHandle:
 
         max_discharge = time_since_last_battery_update * self._max_discharge_rate / 3600
         max_charge = time_since_last_battery_update * self._max_charge_rate / 3600
-        
-        # _LOGGER.debug(
-        #     "(%s) Battery Timings %s = Max Charge / %s = Max Discharge",
-        #     self._name,
-        #     max_charge,
-        #     max_discharge,
-        # )
 
         available_capacity_to_charge = self._battery_size - float(self._charge_state)
         available_capacity_to_discharge = float(self._charge_state) * float(
             self._battery_efficiency
         )
-        
-        # _LOGGER.debug(
-        #     "(%s) Battery Cap. %s = Ava. to Charge / %s = Ava. to Discharge",
-        #     self._name,
-        #     available_capacity_to_charge,
-        #     available_capacity_to_discharge,
-        # )
 
         if not any(self._switches.values()):
             _LOGGER.debug("(%s) Battery normal mode.", self._name)
-           
+
             amount_to_charge = min(
                 export_amount, max_charge, available_capacity_to_charge
             )
@@ -618,5 +614,107 @@ class SimulatedBatteryHandle:
         dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
         
         _LOGGER.debug(
-            "(%s) Battery update complete. Net Import: %s / Net Export %s", self._name, net_import, net_import
+            "(%s) Battery update complete.", self._name
         )
+
+    def update_battery_new(self, import_amount, export_amount):
+        time_now = time.time()
+        time_last_update = self._last_battery_update_time
+        time_since_last_battery_update = time_now - time_last_update
+
+        # Calculate maximum possible charge and discharge
+        max_discharge = time_since_last_battery_update * self._max_discharge_rate / 3600
+        max_charge = time_since_last_battery_update * self._max_charge_rate / 3600
+
+        # Initialize variables
+        amount_to_charge = 0.0
+        amount_to_discharge = 0.0
+        net_export = 0.0
+        net_import = 0.0
+        current_import_tariff = self.get_tarrif_information(self._import_tariff_sensor_id)
+        current_export_tariff = self.get_tarrif_information(self._export_tariff_sensor_id)
+
+        # Update battery mode
+        battery_mode = MODE_IDLE  # Default mode
+
+        if not any(self._switches.values()):
+            amount_to_charge = min(export_amount, max_charge, self._battery_size - self._charge_state)
+            amount_to_discharge = min(import_amount, max_discharge, self._charge_state * self._battery_efficiency)
+            net_import = import_amount - amount_to_discharge
+            net_export = export_amount - amount_to_charge
+            battery_mode = MODE_CHARGING if amount_to_charge > amount_to_discharge else MODE_DISCHARGING
+
+        elif self._switches[PAUSE_BATTERY]:
+            net_export = export_amount
+            net_import = import_amount
+            battery_mode = MODE_IDLE
+
+        elif self._switches[OVERIDE_CHARGING]:
+            amount_to_charge = min(max_charge, self._battery_size - self._charge_state)
+            net_export = max(export_amount - amount_to_charge, 0)
+            net_import = max(amount_to_charge - export_amount, 0) + import_amount
+            self._charging = True
+            battery_mode = MODE_FORCE_CHARGING
+
+        elif self._switches[FORCE_DISCHARGE]:
+            amount_to_discharge = min(max_discharge, available_capacity_to_discharge)
+            net_export = max(amount_to_discharge - import_amount, 0) + export_amount
+            net_import = max(import_amount - amount_to_discharge, 0)
+            battery_mode = MODE_FORCE_DISCHARGING
+
+        elif self._switches[CHARGE_ONLY]:
+            amount_to_charge: float = min( export_amount, max_charge, available_capacity_to_charge )
+            net_import = import_amount
+            net_export = export_amount - amount_to_charge
+            if amount_to_charge > amount_to_discharge:
+                self._sensors[BATTERY_MODE] = MODE_CHARGING
+            else:
+                self._sensors[BATTERY_MODE] = MODE_IDLE
+        
+        else:
+            return
+
+        # Update cost savings based on tariff information
+        if current_import_tariff is not None:
+            self._sensors[ATTR_MONEY_SAVED_IMPORT] += (import_amount - net_import) * current_import_tariff
+        if current_export_tariff is not None:
+            self._sensors[ATTR_MONEY_SAVED_EXPORT] += (net_export - export_amount) * current_export_tariff
+        if self._tariff_type is not NO_TARIFF_INFO:
+            self._sensors[ATTR_MONEY_SAVED] = self._sensors[ATTR_MONEY_SAVED_IMPORT] + self._sensors[ATTR_MONEY_SAVED_EXPORT]
+
+        # Update sensor values
+        self._sensors[GRID_IMPORT_SIM] += net_import
+        self._sensors[GRID_EXPORT_SIM] += net_export
+        self._sensors[ATTR_ENERGY_SAVED] += import_amount - net_import
+        self._sensors[ATTR_ENERGY_BATTERY_IN] += amount_to_charge
+        self._sensors[ATTR_ENERGY_BATTERY_OUT] += amount_to_discharge
+        
+        self._sensors[CHARGING_RATE] = amount_to_charge / (time_since_last_battery_update / 3600)
+        self._sensors[DISCHARGING_RATE] = amount_to_discharge / (time_since_last_battery_update / 3600)
+
+        #TODO: How is a cycle defined, if you stop at 20% and 80% it will significalty improve the life
+        self._sensors[BATTERY_CYCLES] = self._sensors[ATTR_ENERGY_BATTERY_IN] / self._battery_size
+        
+        self._charge_state += amount_to_charge - (amount_to_discharge / self._battery_efficiency)
+        self._charge_percentage = round(100 * self._charge_state / self._battery_size)
+
+        # Update battery mode based on charge percentage
+        if self._charge_percentage < 2:
+            battery_mode = MODE_EMPTY
+        elif self._charge_percentage > 98:
+            battery_mode = MODE_FULL
+
+        # Reset day/week/month counters
+        if time.strftime("%w", time_now) != time.strftime("%w", time.gmtime(time_last_update)):
+            self._energy_saved_today = 0
+        if time.strftime("%U", time_now) != time.strftime("%U", time.gmtime(time_last_update)):
+            self._energy_saved_week = 0
+        if time.strftime("%m", time_now) != time.strftime("%m", time.gmtime(time_last_update)):
+            self._energy_saved_month = 0
+
+        # Update last battery update time
+        self._last_battery_update_time = time_now
+
+        # Send update signal
+        dispatcher_send(self._hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}")
+        _LOGGER.debug("(%s) Battery update complete.", self._name)

--- a/custom_components/battery_sim/button.py
+++ b/custom_components/battery_sim/button.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
 
-from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, GRID_IMPORT_SIM, GRID_EXPORT_SIM
+from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, MESSAGE_TYPE_BATTERY_RESET
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,4 +96,4 @@ class BatteryButton(ButtonEntity):
         return False
 
     async def async_press(self):
-        dispatcher_send(self.hass, f"{self._device_name}-BatteryResetMessage")
+        dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}")

--- a/custom_components/battery_sim/button.py
+++ b/custom_components/battery_sim/button.py
@@ -1,10 +1,8 @@
-"""
-Switch  Platform Device for Battery Sim
-"""
+"""Switch  Platform Device for Battery Sim."""
 import logging
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
+from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, MESSAGE_TYPE_GENERAL
 
@@ -91,4 +89,7 @@ class BatteryButton(ButtonEntity):
         return False
 
     async def async_press(self):
-        dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_GENERAL}")
+        dispatcher_send(
+            self.hass,
+            f"{self._device_name}-{MESSAGE_TYPE_GENERAL}"
+        )

--- a/custom_components/battery_sim/button.py
+++ b/custom_components/battery_sim/button.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
 
-from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, MESSAGE_TYPE_BATTERY_RESET
+from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, MESSAGE_TYPE_GENERAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,13 +23,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add the Wiser System Switch entities."""
     handle = hass.data[DOMAIN][config_entry.entry_id]  # Get Handler
 
-    # Add Defined Buttons
-    battery_buttons = []
-    for button in BATTERY_BUTTONS:
-        battery_buttons.append(
-            BatteryButton(handle, button["name"], button["key"], button["icon"])
-        )
-
+    battery_buttons = [
+        BatteryButton(handle, button["name"], button["key"], button["icon"])
+        for button in BATTERY_BUTTONS
+    ]
     async_add_entities(battery_buttons)
 
     return True
@@ -46,12 +43,10 @@ async def async_setup_platform(
         battery = conf[CONF_BATTERY]
         handle = hass.data[DOMAIN][battery]
 
-    battery_buttons = []
-    for button in BATTERY_BUTTONS:
-        battery_buttons.append(
-            BatteryButton(handle, button["name"], button["key"], button["icon"])
-        )
-
+    battery_buttons = [
+        BatteryButton(handle, button["name"], button["key"], button["icon"])
+        for button in BATTERY_BUTTONS
+    ]
     async_add_entities(battery_buttons)
     return True
 
@@ -66,7 +61,7 @@ class BatteryButton(ButtonEntity):
         self._icon = icon
         self._button_type = button_type
         self._device_name = handle._name
-        self._name = handle._name + " - " + button_type
+        self._name = f"{handle._name} - {button_type}"
         self._type = type
 
     @property
@@ -96,4 +91,4 @@ class BatteryButton(ButtonEntity):
         return False
 
     async def async_press(self):
-        dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}")
+        dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_GENERAL}")

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -46,7 +46,7 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if user_input[BATTERY_TYPE] == "Custom":
                 return await self.async_step_custom()
-            
+
             self._data = BATTERY_OPTIONS[user_input[BATTERY_TYPE]]
             self._data[SETUP_TYPE] = CONFIG_FLOW
             self._data[CONF_NAME] = f"{DOMAIN}: { user_input[BATTERY_TYPE]}"
@@ -117,20 +117,28 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_connectsensors(self, user_input = None):
+    async def async_step_connectsensors(self, user_input=None):
         if user_input is not None:
             self._data[CONF_IMPORT_SENSOR] = user_input[CONF_IMPORT_SENSOR]
             self._data[CONF_EXPORT_SENSOR] = user_input[CONF_EXPORT_SENSOR]
             if self._data[METER_TYPE] == TWO_IMPORT_ONE_EXPORT_METER:
-                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[CONF_SECOND_IMPORT_SENSOR]
+                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[
+                    CONF_SECOND_IMPORT_SENSOR
+                ]
             if self._data[METER_TYPE] == TWO_IMPORT_TWO_EXPORT_METER:
-                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[CONF_SECOND_IMPORT_SENSOR]
-                self._data[CONF_SECOND_EXPORT_SENSOR] = user_input[CONF_SECOND_EXPORT_SENSOR]
+                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[
+                    CONF_SECOND_IMPORT_SENSOR
+                ]
+                self._data[CONF_SECOND_EXPORT_SENSOR] = user_input[
+                    CONF_SECOND_EXPORT_SENSOR
+                ]
             if self._data[TARIFF_TYPE] == NO_TARIFF_INFO:
-                return self.async_create_entry(title=self._data["name"], data=self._data)
+                return self.async_create_entry(
+                    title=self._data["name"], data=self._data
+                )
             else:
                 return await self.async_step_connecttariffsensors()
-    
+
         if self._data[METER_TYPE] == ONE_IMPORT_ONE_EXPORT_METER:
             schema = {
                 vol.Required(CONF_IMPORT_SENSOR): EntitySelector(

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -46,18 +46,15 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if user_input[BATTERY_TYPE] == "Custom":
                 return await self.async_step_custom()
-            else:
-                self._data = BATTERY_OPTIONS[user_input[BATTERY_TYPE]]
-                self._data[SETUP_TYPE] = CONFIG_FLOW
-                self._data[CONF_NAME] = DOMAIN + ": " + user_input[BATTERY_TYPE]
-                await self.async_set_unique_id(self._data[CONF_NAME])
-                self._abort_if_unique_id_configured()
-                return await self.async_step_metertype()
+            
+            self._data = BATTERY_OPTIONS[user_input[BATTERY_TYPE]]
+            self._data[SETUP_TYPE] = CONFIG_FLOW
+            self._data[CONF_NAME] = f"{DOMAIN}: { user_input[BATTERY_TYPE]}"
+            await self.async_set_unique_id(self._data[CONF_NAME])
+            self._abort_if_unique_id_configured()
+            return await self.async_step_metertype()
 
-        battery_options_names = []
-        for battery in BATTERY_OPTIONS:
-            battery_options_names.append(battery)
-
+        battery_options_names = list(BATTERY_OPTIONS)
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -71,7 +68,7 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._data = user_input
             self._data[SETUP_TYPE] = CONFIG_FLOW
-            self._data[CONF_NAME] = DOMAIN + ": " + self._data[CONF_UNIQUE_NAME]
+            self._data[CONF_NAME] = f"{DOMAIN}: {self._data[CONF_UNIQUE_NAME]}"
             await self.async_set_unique_id(self._data[CONF_NAME])
             self._abort_if_unique_id_configured()
             return await self.async_step_metertype()

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -1,6 +1,7 @@
+"""Configuration flow for the Battery."""
 import logging
 import voluptuous as vol
-from distutils import errors
+
 from homeassistant import config_entries
 from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 from homeassistant.components.sensor import SensorDeviceClass
@@ -72,7 +73,6 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(self._data[CONF_NAME])
             self._abort_if_unique_id_configured()
             return await self.async_step_metertype()
-        errors = {"base": "error message"}
 
         return self.async_show_form(
             step_id="custom",
@@ -105,7 +105,11 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             TWO_IMPORT_ONE_EXPORT_METER,
             TWO_IMPORT_TWO_EXPORT_METER,
         ]
-        tariff_types = [NO_TARIFF_INFO, FIXED_NUMERICAL_TARIFFS, TARIFF_SENSOR_ENTITIES]
+        tariff_types = [
+            NO_TARIFF_INFO,
+            FIXED_NUMERICAL_TARIFFS,
+            TARIFF_SENSOR_ENTITIES
+        ]
 
         return self.async_show_form(
             step_id="metertype",
@@ -189,7 +193,10 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._data[CONF_ENERGY_EXPORT_TARIFF] = user_input[
                     CONF_ENERGY_EXPORT_TARIFF
                 ]
-            return self.async_create_entry(title=self._data["name"], data=self._data)
+            return self.async_create_entry(
+                title=self._data["name"],
+                data=self._data
+            )
         if self._data[TARIFF_TYPE] == TARIFF_SENSOR_ENTITIES:
             schema = {
                 vol.Required(CONF_ENERGY_IMPORT_TARIFF): EntitySelector(

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -120,21 +120,20 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_connectsensors(self, user_input=None):
+    async def async_step_connectsensors(self, user_input = None):
         if user_input is not None:
             self._data[CONF_IMPORT_SENSOR] = user_input[CONF_IMPORT_SENSOR]
             self._data[CONF_EXPORT_SENSOR] = user_input[CONF_EXPORT_SENSOR]
             if self._data[METER_TYPE] == TWO_IMPORT_ONE_EXPORT_METER:
-                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[
-                    CONF_SECOND_IMPORT_SENSOR
-                ]
+                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[CONF_SECOND_IMPORT_SENSOR]
+            if self._data[METER_TYPE] == TWO_IMPORT_TWO_EXPORT_METER:
+                self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[CONF_SECOND_IMPORT_SENSOR]
+                self._data[CONF_SECOND_EXPORT_SENSOR] = user_input[CONF_SECOND_EXPORT_SENSOR]
             if self._data[TARIFF_TYPE] == NO_TARIFF_INFO:
-                return self.async_create_entry(
-                    title=self._data["name"], data=self._data
-                )
+                return self.async_create_entry(title=self._data["name"], data=self._data)
             else:
                 return await self.async_step_connecttariffsensors()
-
+    
         if self._data[METER_TYPE] == ONE_IMPORT_ONE_EXPORT_METER:
             schema = {
                 vol.Required(CONF_IMPORT_SENSOR): EntitySelector(

--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -70,7 +70,7 @@ RESET_BATTERY = "reset_battery"
 PERCENTAGE_ENERGY_IMPORT_SAVED = "percentage_import_energy_saved"
 BATTERY_CYCLES = "battery_cycles"
 
-BATTERY_MODE = "battery_mode_now"
+BATTERY_MODE = "Battery_mode_now"
 MODE_IDLE = "Idle/Paused"
 MODE_CHARGING = "Charging"
 MODE_DISCHARGING = "Discharging"

--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -69,7 +69,7 @@ RESET_BATTERY = "reset_battery"
 PERCENTAGE_ENERGY_IMPORT_SAVED = "percentage_import_energy_saved"
 BATTERY_CYCLES = "battery_cycles"
 
-BATTERY_MODE = "Battery_mode_now"
+BATTERY_MODE = "battery_mode_now"
 MODE_IDLE = "Idle/Paused"
 MODE_CHARGING = "Charging"
 MODE_DISCHARGING = "Discharging"

--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -6,9 +6,10 @@ BATTERY_TYPE = "battery"
 
 BATTERY_PLATFORMS = ["sensor", "switch", "button"]
 
-MESSAGE_TYPE_GENERAL = 'BatteryResetMessage'
-MESSAGE_TYPE_BATTERY_RESET = 'BatteryResetSim'
-MESSAGE_TYPE_BATTERY_UPDATE = 'BatteryUpdateMessage'
+MESSAGE_TYPE_GENERAL = "BatteryResetMessage"
+MESSAGE_TYPE_BATTERY_RESET_IMP = "BatteryResetImportSim"
+MESSAGE_TYPE_BATTERY_RESET_EXP = "BatteryResetExportSim"
+MESSAGE_TYPE_BATTERY_UPDATE = "BatteryUpdateMessage"
 
 DATA_UTILITY = "battery_sim_data"
 
@@ -102,6 +103,24 @@ BATTERY_OPTIONS = {
         CONF_BATTERY_MAX_DISCHARGE_RATE: 4.2,
         CONF_BATTERY_MAX_CHARGE_RATE: 4.2,
         CONF_BATTERY_EFFICIENCY: 0.965,
+    },
+    "Enphase 3T (2nd Gen)": {
+        CONF_BATTERY_SIZE: 3.36,
+        CONF_BATTERY_MAX_DISCHARGE_RATE: 1.92,
+        CONF_BATTERY_MAX_CHARGE_RATE: 1.28,
+        CONF_BATTERY_EFFICIENCY: 0.965,
+    },
+    "Enphase 10T (2nd Gen)": {
+        CONF_BATTERY_SIZE: 10.08,
+        CONF_BATTERY_MAX_DISCHARGE_RATE: 5.0,
+        CONF_BATTERY_MAX_CHARGE_RATE: 3.84,
+        CONF_BATTERY_EFFICIENCY: 0.89,
+    },
+    "Enphase 5P (3rd Gen)": {
+        CONF_BATTERY_SIZE: 5.0,
+        CONF_BATTERY_MAX_DISCHARGE_RATE: 5.7,
+        CONF_BATTERY_MAX_CHARGE_RATE: 3.84,
+        CONF_BATTERY_EFFICIENCY: 0.90,
     },
     "Custom": {},
 }

--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -6,6 +6,10 @@ BATTERY_TYPE = "battery"
 
 BATTERY_PLATFORMS = ["sensor", "switch", "button"]
 
+MESSAGE_TYPE_GENERAL = 'BatteryResetMessage'
+MESSAGE_TYPE_BATTERY_RESET = 'BatteryResetSim'
+MESSAGE_TYPE_BATTERY_UPDATE = 'BatteryUpdateMessage'
+
 DATA_UTILITY = "battery_sim_data"
 
 SETUP_TYPE = "setup_type"

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -45,6 +45,7 @@ from .const import (
     MODE_FULL,
     MODE_EMPTY,
     BATTERY_CYCLES,
+    MESSAGE_TYPE_BATTERY_RESET,MESSAGE_TYPE_BATTERY_UPDATE
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -193,18 +194,18 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
                 _LOGGER.debug("Sensor state not restored properly.")
                 if self._sensor_type == GRID_IMPORT_SIM:
                     dispatcher_send(
-                        self.hass, f"{self._device_name}-BatteryResetImportSim"
+                        self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}"
                     )
                 elif self._sensor_type == GRID_EXPORT_SIM:
                     dispatcher_send(
-                        self.hass, f"{self._device_name}-BatteryResetExportSim"
+                        self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}"
                     )
         else:
             _LOGGER.debug("No sensor state - presume new battery.")
             if self._sensor_type == GRID_IMPORT_SIM:
-                dispatcher_send(self.hass, f"{self._device_name}-BatteryResetImportSim")
+                dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}")
             elif self._sensor_type == GRID_EXPORT_SIM:
-                dispatcher_send(self.hass, f"{self._device_name}-BatteryResetExportSim")
+                dispatcher_send(self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET}")
 
         async def async_update_state():
             """Update sensor state."""
@@ -212,7 +213,7 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
             await self.async_update_ha_state(True)
 
         async_dispatcher_connect(
-            self.hass, f"{self._device_name}-BatteryUpdateMessage", async_update_state
+            self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_UPDATE}", async_update_state
         )
 
     @property
@@ -331,7 +332,7 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
             await self.async_update_ha_state(True)
 
         async_dispatcher_connect(
-            self.hass, f"{self._name}-BatteryUpdateMessage", async_update_state
+            self.hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}", async_update_state
         )
 
     @property
@@ -428,7 +429,7 @@ class BatteryStatus(SensorEntity):
             await self.async_update_ha_state(True)
 
         async_dispatcher_connect(
-            self.hass, f"{self._device_name}-BatteryUpdateMessage", async_update_state
+            self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_UPDATE}", async_update_state
         )
 
     @property

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -84,6 +84,7 @@ async def define_sensors(hass, handle):
             UnitOfEnergy.KILO_WATT_HOUR,
         )
     )
+
     sensors.append(
         DisplayOnlySensor(
             handle,
@@ -126,6 +127,7 @@ async def define_sensors(hass, handle):
             UnitOfEnergy.KILO_WATT_HOUR,
         )
     )
+
     sensors.append(DisplayOnlySensor(handle, BATTERY_CYCLES, None, None))
     if handle._import_tariff_sensor_id != None:
         sensors.append(
@@ -377,7 +379,7 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {
+        return {
             ATTR_STATUS: self.handle._sensors[BATTERY_MODE],
             ATTR_CHARGE_PERCENTAGE: int(self.handle._charge_percentage),
             ATTR_DATE_RECORDING_STARTED: self.handle._date_recording_started,
@@ -387,7 +389,6 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
             CONF_BATTERY_MAX_CHARGE_RATE: float(self.handle._max_charge_rate),
             ATTR_SOURCE_ID: self.handle._export_sensor_id,
         }
-        return state_attr
 
     @property
     def icon(self):
@@ -457,8 +458,7 @@ class BatteryStatus(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {}
-        return state_attr
+        return {}
 
     @property
     def icon(self):

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -1,9 +1,13 @@
-"""Simulated battery and associated sensors"""
+"""Simulated battery and associated sensors."""
 import time
 import logging
 
 import homeassistant.util.dt as dt_util
-from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    dispatcher_send,
+    async_dispatcher_connect
+)
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -105,12 +109,18 @@ async def define_sensors(hass, handle):
     )
     sensors.append(
         DisplayOnlySensor(
-            handle, CHARGING_RATE, SensorDeviceClass.POWER, UnitOfPower.KILO_WATT
+            handle,
+            CHARGING_RATE,
+            SensorDeviceClass.POWER,
+            UnitOfPower.KILO_WATT
         )
     )
     sensors.append(
         DisplayOnlySensor(
-            handle, DISCHARGING_RATE, SensorDeviceClass.POWER, UnitOfPower.KILO_WATT
+            handle,
+            DISCHARGING_RATE,
+            SensorDeviceClass.POWER,
+            UnitOfPower.KILO_WATT
         )
     )
     sensors.append(
@@ -163,11 +173,17 @@ async def define_sensors(hass, handle):
 
 
 class DisplayOnlySensor(RestoreEntity, SensorEntity):
-    """Representation of a sensor which simply displays a value calculated in the __init__ file"""
+    """
+    Representation of a sensor.
+
+    This reprisentation simply displays a value calculated
+    in the __init__ file.
+    """
 
     _attr_should_poll = False
 
     def __init__(self, handle, sensor_name, type_of_sensor, units):
+        """Initialize the display only sensors for the battery."""
         self._handle = handle
         self._units = units
         self._name = f"{handle._name} - {sensor_name}"
@@ -179,7 +195,6 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """Subscribe for update from the battery."""
-
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
@@ -187,7 +202,9 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
             try:
                 self._handle._sensors[self._sensor_type] = float(state.state)
                 self._last_reset = dt_util.as_utc(
-                    dt_util.parse_datetime(state.attributes.get(ATTR_LAST_RESET))
+                    dt_util.parse_datetime(
+                        state.attributes.get(ATTR_LAST_RESET)
+                    )
                 )
                 self._available = True
                 await self.async_update_ha_state(True)
@@ -207,11 +224,13 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
             _LOGGER.debug("No sensor state - presume new battery.")
             if self._sensor_type == GRID_IMPORT_SIM:
                 dispatcher_send(
-                    self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_IMP}"
+                    self.hass,
+                    f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_IMP}"
                 )
             elif self._sensor_type == GRID_EXPORT_SIM:
                 dispatcher_send(
-                    self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_EXP}"
+                    self.hass,
+                    f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_EXP}"
                 )
 
         async def async_update_state():
@@ -237,7 +256,10 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {"name": self._device_name, "identifiers": {(DOMAIN, self._device_name)}}
+        return {
+            "name": self._device_name,
+            "identifiers": {(DOMAIN, self._device_name)}
+        }
 
     @property
     def native_value(self):
@@ -279,7 +301,8 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
                 state_attr = {PERCENTAGE_ENERGY_IMPORT_SAVED: 0}
             else:
                 percentage_import_saved = (
-                    100 * (real_world_import - simulated_import) / real_world_import
+                    100 * (real_world_import - simulated_import)
+                    / real_world_import
                 )
                 state_attr = {
                     PERCENTAGE_ENERGY_IMPORT_SAVED: round(
@@ -301,7 +324,8 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
             return round(float(self._handle._sensors[self._sensor_type]), 3)
 
     def update(self):
-        """Not used"""
+        """Not used."""
+        return
 
     @property
     def last_reset(self):
@@ -310,12 +334,15 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available. Needed to avoid spikes in energy dashboard on startup"""
+        """Needed to avoid spikes in energy dashboard on startup.
+
+        Return True if entity is available.
+        """
         return self._available
 
 
 class SimulatedBattery(RestoreEntity, SensorEntity):
-    """Representation of the battery itself"""
+    """Representation of the battery itself."""
 
     _attr_should_poll = False
 
@@ -341,7 +368,9 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
             await self.async_update_ha_state(True)
 
         async_dispatcher_connect(
-            self.hass, f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}", async_update_state
+            self.hass,
+            f"{self._name}-{MESSAGE_TYPE_BATTERY_UPDATE}",
+            async_update_state
         )
 
     @property
@@ -390,20 +419,30 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
-            ATTR_STATUS: self.handle._sensors[BATTERY_MODE],
-            ATTR_CHARGE_PERCENTAGE: int(self.handle._charge_percentage),
-            ATTR_DATE_RECORDING_STARTED: self.handle._date_recording_started,
-            CONF_BATTERY_SIZE: self.handle._battery_size,
-            CONF_BATTERY_EFFICIENCY: float(self.handle._battery_efficiency),
-            CONF_BATTERY_MAX_DISCHARGE_RATE: float(self.handle._max_discharge_rate),
-            CONF_BATTERY_MAX_CHARGE_RATE: float(self.handle._max_charge_rate),
-            ATTR_SOURCE_ID: self.handle._export_sensor_id,
+            ATTR_STATUS:
+                self.handle._sensors[BATTERY_MODE],
+            ATTR_CHARGE_PERCENTAGE:
+                int(self.handle._charge_percentage),
+            ATTR_DATE_RECORDING_STARTED:
+                self.handle._date_recording_started,
+            CONF_BATTERY_SIZE:
+                self.handle._battery_size,
+            CONF_BATTERY_EFFICIENCY:
+                float(self.handle._battery_efficiency),
+            CONF_BATTERY_MAX_DISCHARGE_RATE:
+                float(self.handle._max_discharge_rate),
+            CONF_BATTERY_MAX_CHARGE_RATE:
+                float(self.handle._max_charge_rate),
+            ATTR_SOURCE_ID:
+                self.handle._export_sensor_id,
         }
 
     @property
     def icon(self):
-        """Return the icon to use in the frontend"""
-        if self.handle._sensors[BATTERY_MODE] in [MODE_CHARGING, MODE_FORCE_CHARGING]:
+        """Return the icon to use in the frontend."""
+        if self.handle._sensors[BATTERY_MODE] in [
+            MODE_CHARGING, MODE_FORCE_CHARGING
+        ]:
             return ICON_CHARGING
         if self.handle._sensors[BATTERY_MODE] == MODE_FULL:
             return ICON_FULL
@@ -418,7 +457,7 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
 
 
 class BatteryStatus(SensorEntity):
-    """Representation of the battery itself"""
+    """Representation of the battery itself."""
 
     _attr_should_poll = False
 
@@ -455,7 +494,10 @@ class BatteryStatus(SensorEntity):
 
     @property
     def device_info(self):
-        return {"name": self._device_name, "identifiers": {(DOMAIN, self._device_name)}}
+        return {
+            "name": self._device_name,
+            "identifiers": {(DOMAIN, self._device_name)}
+        }
 
     @property
     def native_value(self):
@@ -474,8 +516,11 @@ class BatteryStatus(SensorEntity):
 
     @property
     def icon(self):
-        """Return the icon to use in the frontend"""
-        if self.handle._sensors[BATTERY_MODE] in [MODE_CHARGING, MODE_FORCE_CHARGING]:
+        """Return the icon to use in the frontend."""
+        if self.handle._sensors[BATTERY_MODE] in [
+            MODE_CHARGING,
+            MODE_FORCE_CHARGING
+        ]:
             return ICON_CHARGING
         if self.handle._sensors[BATTERY_MODE] == MODE_FULL:
             return ICON_FULL

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -77,7 +77,7 @@ async def async_setup_platform(
         async_add_entities(sensors)
 
 
-async def define_sensors(hass, handle): 
+async def define_sensors(hass, handle):
     sensors = []
     sensors.append(
         DisplayOnlySensor(
@@ -131,7 +131,7 @@ async def define_sensors(hass, handle):
     )
 
     sensors.append(DisplayOnlySensor(handle, BATTERY_CYCLES, None, None))
-    if handle._import_tariff_sensor_id != None:
+    if handle._import_tariff_sensor_id is not None:
         sensors.append(
             DisplayOnlySensor(
                 handle,
@@ -148,7 +148,7 @@ async def define_sensors(hass, handle):
                 hass.config.currency,
             )
         )
-    if handle._export_tariff_sensor_id != None:
+    if handle._export_tariff_sensor_id is not None:
         sensors.append(
             DisplayOnlySensor(
                 handle,
@@ -195,11 +195,13 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
                 _LOGGER.debug("Sensor state not restored properly.")
                 if self._sensor_type == GRID_IMPORT_SIM:
                     dispatcher_send(
-                        self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_IMP}"
+                        self.hass,
+                        f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_IMP}",
                     )
                 elif self._sensor_type == GRID_EXPORT_SIM:
                     dispatcher_send(
-                        self.hass, f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_EXP}"
+                        self.hass,
+                        f"{self._device_name}-{MESSAGE_TYPE_BATTERY_RESET_EXP}",
                     )
         else:
             _LOGGER.debug("No sensor state - presume new battery.")

--- a/custom_components/battery_sim/switch.py
+++ b/custom_components/battery_sim/switch.py
@@ -44,13 +44,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add the Wiser System Switch entities."""
     handle = hass.data[DOMAIN][config_entry.entry_id]  # Get Handler
 
-    # Add Defined Switches
-    battery_switches = []
-    for switch in BATTERY_SWITCHES:
-        battery_switches.append(
-            BatterySwitch(handle, switch["name"], switch["key"], switch["icon"])
-        )
-
+    battery_switches = [
+        BatterySwitch(handle, switch["name"], switch["key"], switch["icon"])
+        for switch in BATTERY_SWITCHES
+    ]
     async_add_entities(battery_switches)
 
     return True
@@ -67,12 +64,10 @@ async def async_setup_platform(
         battery = conf[CONF_BATTERY]
         handle = hass.data[DOMAIN][battery]
 
-    battery_switches = []
-    for switch in BATTERY_SWITCHES:
-        battery_switches.append(
-            BatterySwitch(handle, switch["name"], switch["key"], switch["icon"])
-        )
-
+    battery_switches = [
+        BatterySwitch(handle, switch["name"], switch["key"], switch["icon"])
+        for switch in BATTERY_SWITCHES
+    ]
     async_add_entities(battery_switches)
     return True
 

--- a/custom_components/battery_sim/switch.py
+++ b/custom_components/battery_sim/switch.py
@@ -1,6 +1,4 @@
-"""
-Switch  Platform Device for Battery Sim
-"""
+"""Switch  Platform Device for Battery Sim."""
 import logging
 
 from homeassistant.components.switch import SwitchEntity

--- a/custom_components/battery_sim/switch.py
+++ b/custom_components/battery_sim/switch.py
@@ -82,7 +82,7 @@ class BatterySwitch(SwitchEntity):
         self._icon = icon
         self._switch_type = switch_type
         self._device_name = handle._name
-        self._name = handle._name + " - " + switch_type
+        self._name = f"{handle._name} - {switch_type}"
         self._is_on = False
         self._type = type
 

--- a/custom_components/battery_sim/translations/en.json
+++ b/custom_components/battery_sim/translations/en.json
@@ -1,58 +1,58 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "This device is already configured."
+  "config": {
+    "abort": {
+      "already_configured": "This device is already configured."
+    },
+    "error": {
+      "not_float": "Needs to be a number"
+    },
+    "flow_title": "Setup new simulated battery",
+    "step": {
+      "user": {
+        "title": "Select battery",
+        "data": {
+          "battery": "Battery model"
         },
-        "error": { 
-            "not_float": "Needs to be a number"
+        "description": "Select a battery model to simulate from the list or select custom to create one."
+      },
+      "custom": {
+        "title": "Custom battery",
+        "data": {
+          "unique_name": "Unique name",
+          "size_kwh": "Battery size in kWh",
+          "max_discharge_rate_kw": "Maximum discharge rate in kW",
+          "max_charge_rate_kw": "Maximum charging rate in kW",
+          "efficiency": "Round trip efficiency (0 to 1)"
         },
-        "flow_title": "Setup new simulated battery",
-        "step": {
-            "user": {
-                "title": "Select battery",
-                "data":{
-                    "battery": "Battery model"
-                },
-                "description": "Select a battery model to simulate from the list or select custom to create one."
-            },
-            "custom": {
-                "title": "Custom battery",
-                "data":{
-                    "unique_name": "Unique name",
-                    "size_kwh": "Battery size in kWh",
-                    "max_discharge_rate_kw" : "Maximum discharge rate in kW",
-                    "max_charge_rate_kw": "Maximum charging rate in kW",
-                    "efficiency": "Round trip efficiency (0 to 1)"
-                },
-                "description": "Set the speciffications of the battery. Please consider posting details of the battery you are simulating on our github so we can add it to the template list."
-            },
-            "metertype":{
-                "title": "Energy meter type",
-                "data":{
-                    "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter",
-                    "two_import_two_export" : "Two import and two export meter"
-                },
-                "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
-            },
-            "connectsensors": {
-                "title": "Connect battery to energy meter sensors",
-                "data":{
-                    "import_sensor": "Import sensor/meter - energy coming into house",
-                    "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
-                    "export_sensor" : "Export sensor/meter - energy sent to grid",
-                    "second_export_sensor" : "Second export sensor/meter - e.g. night time or Economy 7"
-                },
-                "description": "When export sensor shows energy leaving the house battery will charge. When import sensor shows energy entering the house from the grid the battery will discharge."
-            },
-            "connecttariffsensors": {
-                "title": "Connect sensors or specify fixed value for energy tariffs",
-                "data":{
-                    "energy_import_tariff": "Import tariff/rate - cost of energy from the grid (£/kWh)",
-                    "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
-                },
-                "description": "Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents) so tariff is usualy in the form 0.33 or similar."
-            }
-          }
+        "description": "Set the speciffications of the battery. Please consider posting details of the battery you are simulating on our github so we can add it to the template list."
+      },
+      "metertype": {
+        "title": "Energy meter type",
+        "data": {
+          "one_import_one_export": "One import and one export meter",
+          "two_import_one_export": "Two import and one export meter",
+          "two_import_two_export": "Two import and two export meter"
+        },
+        "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
+      },
+      "connectsensors": {
+        "title": "Connect battery to energy meter sensors",
+        "data": {
+          "import_sensor": "Import sensor/meter - energy coming into house",
+          "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
+          "export_sensor": "Export sensor/meter - energy sent to grid",
+          "second_export_sensor": "Second export sensor/meter - e.g. night time or Economy 7"
+        },
+        "description": "When export sensor shows energy leaving the house battery will charge. When import sensor shows energy entering the house from the grid the battery will discharge."
+      },
+      "connecttariffsensors": {
+        "title": "Connect sensors or specify fixed value for energy tariffs",
+        "data": {
+          "energy_import_tariff": "Import tariff/rate - cost of energy from the grid (£/kWh)",
+          "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
+        },
+        "description": "Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents) so tariff is usualy in the form 0.33 or similar."
+      }
     }
+  }
 }

--- a/custom_components/battery_sim/translations/en.json
+++ b/custom_components/battery_sim/translations/en.json
@@ -30,7 +30,8 @@
                 "title": "Energy meter type",
                 "data":{
                     "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter"
+                    "two_import_one_export" : "Two import and one export meter",
+                    "two_import_two_export" : "Two import and two export meter"
                 },
                 "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
             },

--- a/custom_components/battery_sim/translations/nl.json
+++ b/custom_components/battery_sim/translations/nl.json
@@ -1,56 +1,56 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Het apparaat is reeds geconfigureerd."
+  "config": {
+    "abort": {
+      "already_configured": "Het apparaat is reeds geconfigureerd."
+    },
+    "error": {
+      "not_float": "Moet een getal zijn"
+    },
+    "flow_title": "Nieuwe batterijsimulatie instellen",
+    "step": {
+      "user": {
+        "title": "Selecteer batterij",
+        "data": {
+          "battery": "Batterij model"
         },
-        "error": { 
-            "not_float": "Moet een getal zijn"
+        "description": "Selecteer het te simuleren model uit de lijst, of maak een aangepast model."
+      },
+      "custom": {
+        "title": "Aangepaste batterij",
+        "data": {
+          "size_kwh": "Batterij capaciteit in kWh",
+          "max_discharge_rate_kw": "Maximum ontlaadcapaciteit in kW",
+          "max_charge_rate_kw": "Maximum laadcapaciteit in kW",
+          "efficiency": "AC-DC-AC efficiëntie (0 to 1)"
         },
-        "flow_title": "Nieuwe batterijsimulatie instellen",
-        "step": {
-            "user": {
-                "title": "Selecteer batterij",
-                "data":{
-                    "battery": "Batterij model"
-                },
-                "description": "Selecteer het te simuleren model uit de lijst, of maak een aangepast model."
-            },
-            "custom": {
-                "title": "Aangepaste batterij",
-                "data":{
-                    "size_kwh": "Batterij capaciteit in kWh",
-                    "max_discharge_rate_kw" : "Maximum ontlaadcapaciteit in kW",
-                    "max_charge_rate_kw": "Maximum laadcapaciteit in kW",
-                    "efficiency": "AC-DC-AC efficiëntie (0 to 1)"
-                },
-                "description": "Stel de batterijspecificaties in."
-            },
-            "metertype":{
-                "title": "Energy meter type",
-                "data":{
-                    "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter",
-                    "two_import_two_export" : "Two import and two export meter"
-                },
-                "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
-            },
-           "connectsensors": {
-                "title": "Connect battery to energy meter sensors",
-                "data":{
-                    "import_sensor": "Import sensor/meter - binnenkomende energie van het net",
-                    "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
-                    "export_sensor" : "Export sensor/meter - energy sent to grid"
-                },
-                "description": "De batterij zal opladen wanneer de export sensor aangeeft dat stroom teruggeleverd wordt aan het net. De batterij zal ontladen wanneer de import sensor aangeeft dat stroom van het net gehaald wordt."
-            },
-            "connecttariffsensors": {
-                "title": "Connect sensors for energy tariffs",
-                "data":{
-                    "energy_import_tariff": "Energietarief entiteit - cost of energy from the grid (£/kWh)",
-                    "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
-                },
-                "description": "For static tariffs it is best to create a helper entity with a fixed value. Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents)."
-            }
-         }
+        "description": "Stel de batterijspecificaties in."
+      },
+      "metertype": {
+        "title": "Energy meter type",
+        "data": {
+          "one_import_one_export": "One import and one export meter",
+          "two_import_one_export": "Two import and one export meter",
+          "two_import_two_export": "Two import and two export meter"
+        },
+        "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
+      },
+      "connectsensors": {
+        "title": "Connect battery to energy meter sensors",
+        "data": {
+          "import_sensor": "Import sensor/meter - binnenkomende energie van het net",
+          "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
+          "export_sensor": "Export sensor/meter - energy sent to grid"
+        },
+        "description": "De batterij zal opladen wanneer de export sensor aangeeft dat stroom teruggeleverd wordt aan het net. De batterij zal ontladen wanneer de import sensor aangeeft dat stroom van het net gehaald wordt."
+      },
+      "connecttariffsensors": {
+        "title": "Connect sensors for energy tariffs",
+        "data": {
+          "energy_import_tariff": "Energietarief entiteit - cost of energy from the grid (£/kWh)",
+          "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
+        },
+        "description": "For static tariffs it is best to create a helper entity with a fixed value. Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents)."
+      }
     }
+  }
 }

--- a/custom_components/battery_sim/translations/nl.json
+++ b/custom_components/battery_sim/translations/nl.json
@@ -29,7 +29,8 @@
                 "title": "Energy meter type",
                 "data":{
                     "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter"
+                    "two_import_one_export" : "Two import and one export meter",
+                    "two_import_two_export" : "Two import and two export meter"
                 },
                 "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
             },

--- a/custom_components/battery_sim/translations/sv.json
+++ b/custom_components/battery_sim/translations/sv.json
@@ -1,56 +1,56 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Den här enheten är redan konfigurerad."
+  "config": {
+    "abort": {
+      "already_configured": "Den här enheten är redan konfigurerad."
+    },
+    "error": {
+      "not_float": "Måste vara en siffra"
+    },
+    "flow_title": "Ställ in nytt simulerat batteri",
+    "step": {
+      "user": {
+        "title": "Välj batteri",
+        "data": {
+          "battery": "Batterimodell"
         },
-        "error": { 
-            "not_float": "Måste vara en siffra"
+        "description": "Välj en batterimodell att simulera från listan eller välj anpassad för att skapa en ny."
+      },
+      "custom": {
+        "title": "Anpassat batteri",
+        "data": {
+          "size_kwh": "Batteristorlek i kWh",
+          "max_discharge_rate_kw": "Max urladdningshastighet i kW",
+          "max_charge_rate_kw": "Max laddningshastighet i kW",
+          "efficiency": "Round trip efficiency (0 to 1)"
         },
-        "flow_title": "Ställ in nytt simulerat batteri",
-        "step": {
-            "user": {
-                "title": "Välj batteri",
-                "data":{
-                    "battery": "Batterimodell"
-                },
-                "description": "Välj en batterimodell att simulera från listan eller välj anpassad för att skapa en ny."
-            },
-            "custom": {
-                "title": "Anpassat batteri",
-                "data":{
-                    "size_kwh": "Batteristorlek i kWh",
-                    "max_discharge_rate_kw" : "Max urladdningshastighet i kW",
-                    "max_charge_rate_kw": "Max laddningshastighet i kW",
-                    "efficiency": "Round trip efficiency (0 to 1)"
-                },
-                "description": "Ställ in specifikationerna för batteriet."
-            },
-           "metertype":{
-                "title": "Energy meter type",
-                "data":{
-                    "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter",
-                    "two_import_two_export" : "Two import and two export meter"
-                },
-                "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
-            },
-            "connectsensors": {
-                "title": "Anslut batteri eller energi mätarare",
-                "data":{
-                    "import_sensor": "Importera senor/mätare - inkommande energi",
-                    "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
-                    "export_sensor" : "Exportera sensor/mätare - producering till elnätet"
-                },
-                "description": "När exportsensorn visar energi som lämnar huset laddas batteriet. När importsensorn visar energi som kommer in i huset från nätet laddas batteriet ur."
-            },
-            "connecttariffsensors": {
-                "title": "Connect sensors for energy tariffs",
-                "data":{
-                    "energy_import_tariff": "Import tariff/rate - cost of energy from the grid (£/kWh)",
-                    "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
-                },
-                "description": "For static tariffs it is best to create a helper entity with a fixed value. Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents)."
-            }
-         }
+        "description": "Ställ in specifikationerna för batteriet."
+      },
+      "metertype": {
+        "title": "Energy meter type",
+        "data": {
+          "one_import_one_export": "One import and one export meter",
+          "two_import_one_export": "Two import and one export meter",
+          "two_import_two_export": "Two import and two export meter"
+        },
+        "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
+      },
+      "connectsensors": {
+        "title": "Anslut batteri eller energi mätarare",
+        "data": {
+          "import_sensor": "Importera senor/mätare - inkommande energi",
+          "second_import_sensor": "Second import sensor/meter - e.g. night time or Economy 7",
+          "export_sensor": "Exportera sensor/mätare - producering till elnätet"
+        },
+        "description": "När exportsensorn visar energi som lämnar huset laddas batteriet. När importsensorn visar energi som kommer in i huset från nätet laddas batteriet ur."
+      },
+      "connecttariffsensors": {
+        "title": "Connect sensors for energy tariffs",
+        "data": {
+          "energy_import_tariff": "Import tariff/rate - cost of energy from the grid (£/kWh)",
+          "energy_export_tariff": "Export tariff/rate - payment for energy exported to grid (£/kWh)"
+        },
+        "description": "For static tariffs it is best to create a helper entity with a fixed value. Currency is determined in home assistant location settings and is usually in base unit (e.g. euro) not subunit (e.g. cents)."
+      }
     }
+  }
 }

--- a/custom_components/battery_sim/translations/sv.json
+++ b/custom_components/battery_sim/translations/sv.json
@@ -29,7 +29,8 @@
                 "title": "Energy meter type",
                 "data":{
                     "one_import_one_export" : "One import and one export meter",
-                    "two_import_one_export" : "Two import and one export meter"
+                    "two_import_one_export" : "Two import and one export meter",
+                    "two_import_two_export" : "Two import and two export meter"
                 },
                 "description": "Select the type of energy meter you have. Import meters measure energy coming into your home from the grid. You may have two of these e.g. one for day time and one for night. Export meters measure energy leaving your house to the grid e.g. excess solar generation."
             },


### PR DESCRIPTION
Related to: https://github.com/hif2k1/battery_sim/issues/83

# Outline
So I saw there were some issues with using the second export and import. I've altered the configuration flow, and the mainly the `__init__.py`. All the other edits where mainly some checks with Flake8 and unused objects. 

- Added `self._sensor_collection` for adding all sensors instead of assigning them each a variable. In theory, we can now add <n> amount of sensors. 
- Merged functions that had "mainly" the same code and by specify if it's an Import or Export sensor handle the rest. 
   - Reset: `reset_export_sim_sensor` and `reset_import_sim_sensor` became `reset_sim_sensor`
   - Reading Handler: `async_export_reading` and `async_import_reading` became `start_sensor_tracking` inside `async_source_tracking`
- Converted all strings to f-strings, except the Logging once.
- Standardized the "Message" strings, to prevent typo's
- Added some batteries from Enphase, since that is a potential battery for us.

## To-do

- [x] Update latest code from Local HASS instance. 
- [x] Remove TODO's
- [x] Format code 
- [x] Check for spelling error's
- [x] Check for unused variables, constants and functions.

This is the configuration flow file.

```python
if self._data[METER_TYPE] == TWO_IMPORT_TWO_EXPORT_METER:
	self._data[CONF_SECOND_IMPORT_SENSOR] = user_input[CONF_SECOND_IMPORT_SENSOR]
	self._data[CONF_SECOND_EXPORT_SENSOR] = user_input[CONF_SECOND_EXPORT_SENSOR]
```

```json
{
   "size_kwh":9.3,
   "max_discharge_rate_kw":5.0,
   "max_charge_rate_kw":3.3,
   "efficiency":0.95,
   "setup_type":"config_flow",
   "name":"battery_sim: LG Chem",
   "type_of_energy_meter":"two_import_two_export",
   "tariff_type":"No tariff information",
   "import_sensor":"sensor.energy_consumption_tarif_1",
   "export_sensor":"sensor.energy_production_tarif_1",
   "second_import_sensor":"sensor.energy_consumption_tarif_2",
   "second_export_sensor":"sensor.energy_production_tarif_2"
}
```

```log
2023-08-11 23:07:02.358 DEBUG (MainThread) [custom_components.battery_sim] <battery_sim: LG Chem> monitoring sensor.energy_consumption_tarif_1
2023-08-11 23:07:02.358 DEBUG (MainThread) [custom_components.battery_sim] <battery_sim: LG Chem> monitoring sensor.energy_consumption_tarif_2
2023-08-11 23:07:02.358 DEBUG (MainThread) [custom_components.battery_sim] <battery_sim: LG Chem> monitoring sensor.energy_production_tarif_1
2023-08-11 23:07:02.358 DEBUG (MainThread) [custom_components.battery_sim] <battery_sim: LG Chem> monitoring sensor.energy_production_tarif_2
```