### PR TITLE
Added HomeWizard battery to examples

### DIFF
--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -231,5 +231,11 @@ BATTERY_OPTIONS = {
         CONF_BATTERY_MAX_CHARGE_RATE: 11.5,
         CONF_BATTERY_MAX_DISCHARGE_RATE: 11.5,
     },
+    "HomeWizard Energy Plug-in Battery 2.7kWh": {
+        CONF_BATTERY_SIZE: 2.688,
+        CONF_BATTERY_EFFICIENCY: 0.95,
+        CONF_BATTERY_MAX_CHARGE_RATE: 0.8,
+        CONF_BATTERY_MAX_DISCHARGE_RATE: 0.8,
+    },
     "Custom": {},
 }


### PR DESCRIPTION
Dutch smart-energy company HomeWizard Energy is selling a pre orders for a "works with Home Assistant"-labeled plug-in battery, which I added to the templates.

https://www.homewizard.com/nl/shop/battery-pre-order/

![image](https://github.com/user-attachments/assets/3d0592ef-1102-4618-b6a1-7c2508deaeaf)
