### PR TITLE
Replace deprecated async_forward_entry_setup method

### DIFF
--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -133,10 +133,9 @@ async def async_setup_entry(hass, entry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = handle
     handle._listeners.append(entry.add_update_listener(async_update_settings))
 
-    for platform in BATTERY_PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, BATTERY_PLATFORMS)
+    )
     return True
 
 


### PR DESCRIPTION
The new async_forward_entry_setups method accepts the whole BATTERY_PLATFORMS Iterable, so the module doesn't have to do the iteration itself. See https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ for reference.

Fixes #134 and #140 .