### PR TITLE
Add the infinite battery configuration

### DIFF
--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -237,5 +237,11 @@ BATTERY_OPTIONS = {
         CONF_BATTERY_MAX_CHARGE_RATE: 0.8,
         CONF_BATTERY_MAX_DISCHARGE_RATE: 0.8,
     },
+    "The Infinite Battery": {
+        CONF_BATTERY_SIZE: 1000000,
+        CONF_BATTERY_EFFICIENCY: 1,
+        CONF_BATTERY_MAX_CHARGE_RATE: 100,
+        CONF_BATTERY_MAX_DISCHARGE_RATE: 100,
+    },
     "Custom": {},
 }


### PR DESCRIPTION
This PR fulfills part 1/2 of feature request #154

@hif2k1 It depends on your philosophy if this should be a configurable battery or that you'd rather have people configuring their own, since it's a virtual one.