### PR TITLE
Fix #162: Adjusted HWE-battery efficiency

### DIFF
--- a/custom_components/battery_sim/const.py
+++ b/custom_components/battery_sim/const.py
@@ -235,7 +235,7 @@ BATTERY_OPTIONS = {
     },
     "HomeWizard Energy Plug-in Battery 2.7kWh": {
         CONF_BATTERY_SIZE: 2.473,
-        CONF_BATTERY_EFFICIENCY: 0.95,
+        CONF_BATTERY_EFFICIENCY: 0.75,
         CONF_BATTERY_MAX_CHARGE_RATE: 0.8,
         CONF_BATTERY_MAX_DISCHARGE_RATE: 0.8,
     },


### PR DESCRIPTION
Fix #162: After two months of personal use, the in kWh vs out kWh efficiency of the HomeWizard Plug-In Battery turns out to be around ~75%. Therefore, the preset is adjusted.