### PR TITLE
Add cleanup for empty battery devices in leftover registry

### DIFF
--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -93,6 +93,7 @@ from .const import (
     SIMULATED_SENSOR,
 )
 from .helpers import (
+    find_empty_battery_devices,
     find_leftover_entity_registry_entries,
     generate_input_list,
     interpolate_efficiency,
@@ -340,35 +341,48 @@ async def async_setup_entry(hass, entry) -> bool:
 
     handle._listeners.append(entry.add_update_listener(async_update_settings))
 
-    _log_leftover_entity_registry_entries(hass, entry)
+    _log_leftover_registry_entries(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, BATTERY_PLATFORMS)
 
     return True
 
 
-def _log_leftover_entity_registry_entries(hass, entry):
-    """Log stale entity registry entries for a battery config entry."""
+def _log_leftover_registry_entries(hass, entry):
+    """Log stale entities and empty devices for a battery config entry."""
     entity_reg = er.async_get(hass)
     device_reg = dr.async_get(hass)
     leftovers = find_leftover_entity_registry_entries(
         entity_reg, device_reg, entry.data, entry.entry_id
     )
-    if not leftovers:
-        return
+    if leftovers:
+        _LOGGER.warning(
+            "Battery Sim '%s' has leftover entities that are no longer used by the "
+            "current settings: %s. Use the options flow item 'Delete leftover "
+            "entities and empty devices' to remove them.",
+            entry.data[CONF_NAME],
+            ", ".join(entry.entity_id for entry in leftovers),
+        )
 
-    _LOGGER.warning(
-        "Battery Sim '%s' has leftover entities that are no longer used by the "
-        "current settings: %s. Use the options flow item 'Delete leftover "
-        "entities' to remove them.",
-        entry.data[CONF_NAME],
-        ", ".join(entry.entity_id for entry in leftovers),
+    empty_devices = find_empty_battery_devices(
+        entity_reg, device_reg, entry.data, entry.entry_id
     )
+    if empty_devices:
+        _LOGGER.warning(
+            "Battery Sim '%s' has devices without any entities: %s. Use the "
+            "options flow item 'Delete leftover entities and empty devices' to "
+            "remove them.",
+            entry.data[CONF_NAME],
+            ", ".join(
+                device.name_by_user or device.name or device.id
+                for device in empty_devices
+            ),
+        )
 
 
 async def async_update_settings(hass, entry):
     _LOGGER.warning(f"Config change detected {entry.data[CONF_NAME]}")
-    _log_leftover_entity_registry_entries(hass, entry)
+    _log_leftover_registry_entries(hass, entry)
     await hass.config_entries.async_reload(entry.entry_id)
     return
 

--- a/custom_components/battery_sim/__init__.py
+++ b/custom_components/battery_sim/__init__.py
@@ -93,6 +93,7 @@ from .const import (
     SIMULATED_SENSOR,
 )
 from .helpers import (
+    device_display_name,
     find_empty_battery_devices,
     find_leftover_entity_registry_entries,
     generate_input_list,
@@ -373,10 +374,7 @@ def _log_leftover_registry_entries(hass, entry):
             "options flow item 'Delete leftover entities and empty devices' to "
             "remove them.",
             entry.data[CONF_NAME],
-            ", ".join(
-                device.name_by_user or device.name or device.id
-                for device in empty_devices
-            ),
+            ", ".join(device_display_name(device) for device in empty_devices),
         )
 
 

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -48,6 +48,7 @@ from .const import (
     SIMULATED_SENSOR,
 )
 from .helpers import (
+    find_empty_battery_devices,
     find_leftover_entity_registry_entries,
     generate_input_list,
     validate_efficiency_config,
@@ -342,31 +343,54 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def async_step_delete_leftover_entities(self, user_input=None):
-        """Delete stale entity registry entries for this battery."""
+        """Delete stale entity registry entries and empty devices for this battery."""
         entity_reg = er.async_get(self.hass)
         device_reg = dr.async_get(self.hass)
+        battery_name = self.updated_entry[CONF_NAME]
         leftovers = find_leftover_entity_registry_entries(
             entity_reg,
             device_reg,
             self.updated_entry,
             self._active_config_entry.entry_id,
         )
-        if not leftovers:
+        if leftovers:
+            leftover_entity_ids = [entry.entity_id for entry in leftovers]
+            for entry in leftovers:
+                entity_reg.async_remove(entry.entity_id)
+            _LOGGER.warning(
+                "Deleted leftover Battery Sim entities for '%s': %s",
+                battery_name,
+                ", ".join(leftover_entity_ids),
+            )
+        else:
             _LOGGER.warning(
                 "No leftover Battery Sim entities found for '%s'.",
-                self.updated_entry[CONF_NAME],
+                battery_name,
             )
-            return await self.async_step_init()
 
-        leftover_entity_ids = [entry.entity_id for entry in leftovers]
-        for entry in leftovers:
-            entity_reg.async_remove(entry.entity_id)
-
-        _LOGGER.warning(
-            "Deleted leftover Battery Sim entities for '%s': %s",
-            self.updated_entry[CONF_NAME],
-            ", ".join(leftover_entity_ids),
+        empty_devices = find_empty_battery_devices(
+            entity_reg,
+            device_reg,
+            self.updated_entry,
+            self._active_config_entry.entry_id,
         )
+        if empty_devices:
+            empty_device_names = [
+                device.name_by_user or device.name or device.id
+                for device in empty_devices
+            ]
+            for device in empty_devices:
+                device_reg.async_remove_device(device.id)
+            _LOGGER.warning(
+                "Deleted empty Battery Sim devices for '%s': %s",
+                battery_name,
+                ", ".join(empty_device_names),
+            )
+        else:
+            _LOGGER.warning(
+                "No empty Battery Sim devices found for '%s'.",
+                battery_name,
+            )
         return await self.async_step_init()
 
     async def async_step_main_params(self, user_input=None):

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -48,9 +48,8 @@ from .const import (
     SIMULATED_SENSOR,
 )
 from .helpers import (
-    find_empty_battery_devices,
-    find_leftover_entity_registry_entries,
     generate_input_list,
+    purge_leftover_battery_registry_entries,
     validate_efficiency_config,
 )
 
@@ -347,20 +346,19 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
         entity_reg = er.async_get(self.hass)
         device_reg = dr.async_get(self.hass)
         battery_name = self.updated_entry[CONF_NAME]
-        leftovers = find_leftover_entity_registry_entries(
-            entity_reg,
-            device_reg,
-            self.updated_entry,
-            self._active_config_entry.entry_id,
+        removed_entity_ids, removed_device_names = (
+            purge_leftover_battery_registry_entries(
+                entity_reg,
+                device_reg,
+                self.updated_entry,
+                self._active_config_entry.entry_id,
+            )
         )
-        if leftovers:
-            leftover_entity_ids = [entry.entity_id for entry in leftovers]
-            for entry in leftovers:
-                entity_reg.async_remove(entry.entity_id)
+        if removed_entity_ids:
             _LOGGER.warning(
                 "Deleted leftover Battery Sim entities for '%s': %s",
                 battery_name,
-                ", ".join(leftover_entity_ids),
+                ", ".join(removed_entity_ids),
             )
         else:
             _LOGGER.warning(
@@ -368,23 +366,11 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
                 battery_name,
             )
 
-        empty_devices = find_empty_battery_devices(
-            entity_reg,
-            device_reg,
-            self.updated_entry,
-            self._active_config_entry.entry_id,
-        )
-        if empty_devices:
-            empty_device_names = [
-                device.name_by_user or device.name or device.id
-                for device in empty_devices
-            ]
-            for device in empty_devices:
-                device_reg.async_remove_device(device.id)
+        if removed_device_names:
             _LOGGER.warning(
                 "Deleted empty Battery Sim devices for '%s': %s",
                 battery_name,
-                ", ".join(empty_device_names),
+                ", ".join(removed_device_names),
             )
         else:
             _LOGGER.warning(

--- a/custom_components/battery_sim/helpers.py
+++ b/custom_components/battery_sim/helpers.py
@@ -284,6 +284,11 @@ def battery_device_registry_ids(device_registry, config, entry_id=None):
     return device_ids
 
 
+def device_display_name(device):
+    """Return a human-readable label for a device registry entry."""
+    return device.name_by_user or device.name or device.id
+
+
 def _entity_registry_entries_for_device(entity_registry, device_id):
     """Return entity registry entries for a device."""
     return er.async_entries_for_device(entity_registry, device_id)
@@ -321,3 +326,29 @@ def find_empty_battery_devices(entity_registry, device_registry, config, entry_i
         if device is not None:
             empty_devices.append(device)
     return empty_devices
+
+
+def purge_leftover_battery_registry_entries(
+    entity_registry, device_registry, config, entry_id=None
+):
+    """Delete leftover battery entities, then delete battery devices left empty.
+
+    The empty-device scan deliberately runs after the entity removal so that
+    devices holding only leftover entities are cleaned up in the same pass.
+    Returns the removed entity IDs and the removed devices' display names.
+    """
+    leftovers = find_leftover_entity_registry_entries(
+        entity_registry, device_registry, config, entry_id
+    )
+    removed_entity_ids = [entry.entity_id for entry in leftovers]
+    for entry in leftovers:
+        entity_registry.async_remove(entry.entity_id)
+
+    empty_devices = find_empty_battery_devices(
+        entity_registry, device_registry, config, entry_id
+    )
+    removed_device_names = [device_display_name(device) for device in empty_devices]
+    for device in empty_devices:
+        device_registry.async_remove_device(device.id)
+
+    return removed_entity_ids, removed_device_names

--- a/custom_components/battery_sim/helpers.py
+++ b/custom_components/battery_sim/helpers.py
@@ -304,3 +304,20 @@ def find_leftover_entity_registry_entries(
                 continue
             leftovers.append(entry)
     return leftovers
+
+
+def find_empty_battery_devices(entity_registry, device_registry, config, entry_id=None):
+    """Return registered battery devices that no longer have any entities."""
+    empty_devices = []
+    for device_id in battery_device_registry_ids(device_registry, config, entry_id):
+        # Disabled entities still belong to the device, so a device that only
+        # has disabled entities must not be treated as empty.
+        entries = er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=True
+        )
+        if entries:
+            continue
+        device = device_registry.async_get(device_id)
+        if device is not None:
+            empty_devices.append(device)
+    return empty_devices

--- a/custom_components/battery_sim/translations/de.json
+++ b/custom_components/battery_sim/translations/de.json
@@ -89,7 +89,7 @@
         "menu_options": {
           "main_params": "Hauptparameter",
           "input_sensors": "Zähler/Sensoren bearbeiten",
-          "delete_leftover_entities": "Übrig gebliebene Entitäten löschen",
+          "delete_leftover_entities": "Übrig gebliebene Entitäten und leere Geräte löschen",
           "all_done": "Alles erledigt"
         }
       },
@@ -172,8 +172,8 @@
         "description": ""
       },
       "delete_leftover_entities": {
-        "title": "Übrig gebliebene Entitäten löschen",
-        "description": "Veraltete Battery-Sim-Entitäten löschen, die für diese Batterie noch registriert sind, aber von den aktuellen Einstellungen nicht mehr verwendet werden.",
+        "title": "Übrig gebliebene Entitäten und leere Geräte löschen",
+        "description": "Veraltete Battery-Sim-Entitäten löschen, die für diese Batterie noch registriert sind, aber von den aktuellen Einstellungen nicht mehr verwendet werden. Anschließend werden auch Batteriegeräte gelöscht, die keine Entitäten mehr enthalten.",
         "data": {}
       }
     }

--- a/custom_components/battery_sim/translations/en.json
+++ b/custom_components/battery_sim/translations/en.json
@@ -89,7 +89,7 @@
         "menu_options": {
           "main_params": "Main Parameters",
           "input_sensors": "Edit Meters/Sensors",
-          "delete_leftover_entities": "Delete leftover entities",
+          "delete_leftover_entities": "Delete leftover entities and empty devices",
           "all_done": "All done"
         }
       },
@@ -172,8 +172,8 @@
         "description": ""
       },
       "delete_leftover_entities": {
-        "title": "Delete leftover entities",
-        "description": "Delete stale Battery Sim entities that are still registered for this battery but are no longer used by the current settings.",
+        "title": "Delete leftover entities and empty devices",
+        "description": "Delete stale Battery Sim entities that are still registered for this battery but are no longer used by the current settings. Afterwards, battery devices left without any entities are deleted as well.",
         "data": {}
       }
     }

--- a/custom_components/battery_sim/translations/nl.json
+++ b/custom_components/battery_sim/translations/nl.json
@@ -89,7 +89,7 @@
         "menu_options": {
           "main_params": "Hoofdparameters",
           "input_sensors": "Meters/sensoren bewerken",
-          "delete_leftover_entities": "Overgebleven entiteiten verwijderen",
+          "delete_leftover_entities": "Overgebleven entiteiten en lege apparaten verwijderen",
           "all_done": "Alles klaar"
         }
       },
@@ -172,8 +172,8 @@
         "description": ""
       },
       "delete_leftover_entities": {
-        "title": "Overgebleven entiteiten verwijderen",
-        "description": "Verwijder verouderde Battery Sim-entiteiten die nog voor deze batterij zijn geregistreerd, maar niet meer door de huidige instellingen worden gebruikt.",
+        "title": "Overgebleven entiteiten en lege apparaten verwijderen",
+        "description": "Verwijder verouderde Battery Sim-entiteiten die nog voor deze batterij zijn geregistreerd, maar niet meer door de huidige instellingen worden gebruikt. Daarna worden ook batterijapparaten zonder entiteiten verwijderd.",
         "data": {}
       }
     }

--- a/custom_components/battery_sim/translations/sv.json
+++ b/custom_components/battery_sim/translations/sv.json
@@ -89,7 +89,7 @@
         "menu_options": {
           "main_params": "Huvudparametrar",
           "input_sensors": "Redigera mätare/sensorer",
-          "delete_leftover_entities": "Ta bort överblivna entiteter",
+          "delete_leftover_entities": "Ta bort överblivna entiteter och tomma enheter",
           "all_done": "Allt klart"
         }
       },
@@ -172,8 +172,8 @@
         "description": ""
       },
       "delete_leftover_entities": {
-        "title": "Ta bort överblivna entiteter",
-        "description": "Ta bort inaktuella Battery Sim-entiteter som fortfarande är registrerade för detta batteri men inte längre används av de aktuella inställningarna.",
+        "title": "Ta bort överblivna entiteter och tomma enheter",
+        "description": "Ta bort inaktuella Battery Sim-entiteter som fortfarande är registrerade för detta batteri men inte längre används av de aktuella inställningarna. Därefter tas även batterienheter utan entiteter bort.",
         "data": {}
       }
     }


### PR DESCRIPTION
## Summary
Extended the leftover registry cleanup functionality to also detect and remove empty battery devices (devices without any entities) in addition to stale entities.

## Key Changes
- **New helper function**: Added `find_empty_battery_devices()` in `helpers.py` to identify battery devices that no longer have any associated entities
- **Enhanced cleanup flow**: Updated `async_step_delete_leftover_entities()` in `config_flow.py` to:
  - Delete leftover entities (existing behavior)
  - Delete empty devices after entity cleanup (new behavior)
  - Provide detailed logging for both operations
- **Improved logging**: Refactored `_log_leftover_entity_registry_entries()` to `_log_leftover_registry_entries()` in `__init__.py` to report both stale entities and empty devices on startup and config changes
- **Updated UI labels and descriptions**: Modified all translation files (en, de, nl, sv) to reflect the expanded functionality of the cleanup operation

## Implementation Details
- The `find_empty_battery_devices()` function checks devices associated with a battery config entry and returns those with no entities (including disabled entities)
- Empty devices are only removed after leftover entities are cleaned up, ensuring a complete cleanup process
- Logging distinguishes between cases where leftovers/empty devices are found vs. not found
- The cleanup operation now provides comprehensive feedback on all removed items (entities and devices)

https://claude.ai/code/session_01QwnXJpYYwXcey7hgv2JLNL

## Summary by Sourcery

Extend leftover cleanup for Battery Sim to handle both stale entities and empty devices, with clearer logging and options-flow messaging.

New Features:
- Add detection and removal of empty battery devices that no longer have any associated entities during the cleanup flow.

Enhancements:
- Expand startup and config-change logging to report both leftover entities and empty devices and guide users to the combined cleanup option.
- Refine the options flow cleanup step to always log whether leftover entities and empty devices were found or removed.

Documentation:
- Update translations and UI text to describe the extended cleanup of leftover entities and empty devices.