### PR TITLE
Add comprehensive test suite with CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.13"
+          cache: "pip"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest --cov=custom_components.battery_sim --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 __pycache__/
 *.pyc
+.venv/
+.pytest_cache/
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -241,6 +241,19 @@ logger:
 
 to your configuration.yaml and then restarting. If you leave it to run for a few minutes go to logs then and click "load full log" you should see entries from the battery saying it's been set up and then each time it receives an update. If you need to raise an issue then including this code is helpful.
 
+## Development
+
+The integration has a test suite under `tests/` based on
+[pytest-homeassistant-custom-component](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component).
+To run it locally (Python 3.13 recommended):
+
+```
+pip install -r requirements_test.txt
+pytest
+```
+
+Tests also run automatically on every push and pull request via GitHub Actions.
+
 ## Acknowledgements
 
 Original idea and integration developed by hif2k1. Further work in cooperation with dewi-ny-je.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+norecursedirs = [".git", ".venv"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+pytest-homeassistant-custom-component==0.13.316

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the battery_sim integration."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,159 @@
+"""Shared constants and helpers for battery_sim tests."""
+from copy import deepcopy
+
+import homeassistant.util.dt as dt_util
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, UnitOfEnergy
+
+from custom_components.battery_sim.const import (
+    CONF_BATTERY_CHARGE_EFFICIENCY,
+    CONF_BATTERY_DISCHARGE_EFFICIENCY,
+    CONF_BATTERY_MAX_CHARGE_RATE,
+    CONF_BATTERY_MAX_DISCHARGE_RATE,
+    CONF_BATTERY_SIZE,
+    CONF_END_OF_LIFE_DEGRADATION,
+    CONF_INPUT_LIST,
+    CONF_MINIMUM_USER_SELECTABLE_SOC,
+    CONF_NOMINAL_INVERTER_POWER,
+    CONF_RATED_BATTERY_CYCLES,
+    CONF_SOLAR_ENERGY_SENSOR,
+    CONF_UPDATE_FREQUENCY,
+    CONFIG_FLOW,
+    EXPORT,
+    FIXED_TARIFF,
+    GRID_EXPORT_SIM,
+    GRID_IMPORT_SIM,
+    IMPORT,
+    NO_TARIFF_INFO,
+    SENSOR_ID,
+    SENSOR_TYPE,
+    SETUP_TYPE,
+    SIMULATED_SENSOR,
+    TARIFF_SENSOR,
+    TARIFF_TYPE,
+)
+
+BATTERY_NAME = "test_battery"
+IMPORT_SENSOR_ID = "sensor.test_import_energy"
+EXPORT_SENSOR_ID = "sensor.test_export_energy"
+SOLAR_SENSOR_ID = "sensor.test_solar_energy"
+IMPORT_TARIFF_SENSOR_ID = "sensor.test_import_tariff"
+EXPORT_TARIFF_SENSOR_ID = "sensor.test_export_tariff"
+
+IMPORT_TARIFF = 0.30
+EXPORT_TARIFF = 0.10
+
+BATTERY_ENTITY_ID = "sensor.test_battery"
+BATTERY_MODE_SENSOR_ID = "sensor.test_battery_battery_mode_now"
+ENERGY_SAVED_SENSOR_ID = "sensor.test_battery_total_energy_saved"
+ENERGY_IN_SENSOR_ID = "sensor.test_battery_battery_energy_in"
+ENERGY_OUT_SENSOR_ID = "sensor.test_battery_battery_energy_out"
+CHARGING_RATE_SENSOR_ID = "sensor.test_battery_current_charging_rate"
+DISCHARGING_RATE_SENSOR_ID = "sensor.test_battery_current_discharging_rate"
+CHARGE_EFFICIENCY_SENSOR_ID = "sensor.test_battery_last_charge_efficiency"
+DISCHARGE_EFFICIENCY_SENSOR_ID = "sensor.test_battery_last_discharge_efficiency"
+SIM_IMPORT_SENSOR_ID = (
+    "sensor.test_battery_simulated_grid_import_after_battery_discharging"
+)
+SIM_EXPORT_SENSOR_ID = (
+    "sensor.test_battery_simulated_grid_export_after_battery_charging"
+)
+CYCLES_SENSOR_ID = "sensor.test_battery_battery_cycles"
+DEGRADATION_SENSOR_ID = "sensor.test_battery_battery_degradation"
+MONEY_SAVED_IMPORT_SENSOR_ID = "sensor.test_battery_money_saved_on_imports"
+MONEY_SAVED_SENSOR_ID = "sensor.test_battery_total_money_saved"
+MONEY_SAVED_EXPORT_SENSOR_ID = "sensor.test_battery_extra_money_earned_on_exports"
+AVERAGE_VALUE_SENSOR_ID = "sensor.test_battery_average_energy_value"
+SOLAR_CAP_SENSOR_ID = "sensor.test_battery_solar_power_cap"
+PAUSE_SWITCH_ID = "switch.test_battery_pause_battery"
+RESET_BUTTON_ID = "button.test_battery_reset_battery"
+MODE_SELECT_ID = "select.test_battery_battery_mode"
+CHARGE_LIMIT_NUMBER_ID = "number.test_battery_charge_limit"
+DISCHARGE_LIMIT_NUMBER_ID = "number.test_battery_discharge_limit"
+MINIMUM_SOC_NUMBER_ID = "number.test_battery_minimum_soc"
+MAXIMUM_SOC_NUMBER_ID = "number.test_battery_maximum_soc"
+
+KWH_ATTRIBUTES = {
+    ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+    "device_class": "energy",
+    "state_class": "total_increasing",
+}
+WH_ATTRIBUTES = {
+    ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.WATT_HOUR,
+    "device_class": "energy",
+    "state_class": "total_increasing",
+}
+
+BASE_CONFIG = {
+    SETUP_TYPE: CONFIG_FLOW,
+    CONF_NAME: BATTERY_NAME,
+    CONF_BATTERY_SIZE: 10.0,
+    CONF_BATTERY_MAX_DISCHARGE_RATE: 5.0,
+    CONF_BATTERY_MAX_CHARGE_RATE: 4.0,
+    CONF_BATTERY_DISCHARGE_EFFICIENCY: 0.9,
+    CONF_BATTERY_CHARGE_EFFICIENCY: 0.8,
+    CONF_RATED_BATTERY_CYCLES: 6000.0,
+    CONF_END_OF_LIFE_DEGRADATION: 0.8,
+    CONF_UPDATE_FREQUENCY: 60,
+    CONF_MINIMUM_USER_SELECTABLE_SOC: 0.0,
+    CONF_INPUT_LIST: [
+        {
+            SENSOR_ID: IMPORT_SENSOR_ID,
+            SENSOR_TYPE: IMPORT,
+            SIMULATED_SENSOR: GRID_IMPORT_SIM,
+            TARIFF_TYPE: NO_TARIFF_INFO,
+        },
+        {
+            SENSOR_ID: EXPORT_SENSOR_ID,
+            SENSOR_TYPE: EXPORT,
+            SIMULATED_SENSOR: GRID_EXPORT_SIM,
+            TARIFF_TYPE: NO_TARIFF_INFO,
+        },
+    ],
+}
+
+
+def base_config(**overrides):
+    """Return a copy of the standard test battery configuration."""
+    config = deepcopy(BASE_CONFIG)
+    config.update(overrides)
+    return config
+
+
+def config_with_fixed_tariffs(**overrides):
+    """Return a config whose import/export inputs carry fixed tariffs."""
+    config = base_config(**overrides)
+    config[CONF_INPUT_LIST][0][TARIFF_TYPE] = FIXED_TARIFF
+    config[CONF_INPUT_LIST][0][FIXED_TARIFF] = IMPORT_TARIFF
+    config[CONF_INPUT_LIST][1][TARIFF_TYPE] = FIXED_TARIFF
+    config[CONF_INPUT_LIST][1][FIXED_TARIFF] = EXPORT_TARIFF
+    return config
+
+
+def config_with_tariff_sensors(**overrides):
+    """Return a config whose import/export inputs use tariff sensor entities."""
+    config = base_config(**overrides)
+    config[CONF_INPUT_LIST][0][TARIFF_TYPE] = TARIFF_SENSOR
+    config[CONF_INPUT_LIST][0][TARIFF_SENSOR] = IMPORT_TARIFF_SENSOR_ID
+    config[CONF_INPUT_LIST][1][TARIFF_TYPE] = TARIFF_SENSOR
+    config[CONF_INPUT_LIST][1][TARIFF_SENSOR] = EXPORT_TARIFF_SENSOR_ID
+    return config
+
+
+def config_with_solar(nominal_inverter_power=None, **overrides):
+    """Return a config with a solar production sensor configured."""
+    config = base_config(**overrides)
+    config[CONF_SOLAR_ENERGY_SENSOR] = SOLAR_SENSOR_ID
+    if nominal_inverter_power is not None:
+        config[CONF_NOMINAL_INVERTER_POWER] = nominal_inverter_power
+    return config
+
+
+def rewind_last_update(handle, seconds):
+    """Pretend the last battery update happened `seconds` ago."""
+    handle._last_battery_update_time = dt_util.utcnow().timestamp() - seconds
+
+
+def link_meter_readings(handle):
+    """Mark the import/export inputs as the most recently read meters."""
+    handle._last_import_reading_sensor_data = handle._inputs[0]
+    handle._last_export_reading_sensor_data = handle._inputs[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,86 @@
+"""Fixtures for battery_sim tests."""
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+
+from custom_components.battery_sim import SimulatedBatteryHandle
+from custom_components.battery_sim.const import DOMAIN
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .common import base_config
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading the custom integration in all tests."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_battery_sim(hass):
+    """Unload config entries and release leftover listeners after each test."""
+    yield
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.state is ConfigEntryState.LOADED:
+            await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Handles created outside config entries (YAML setup) keep their own
+    # listeners and timers; release them so no timers linger after the test.
+    domain_data = hass.data.get(DOMAIN)
+    if isinstance(domain_data, dict):
+        for key, handle in list(domain_data.items()):
+            if not isinstance(handle, SimulatedBatteryHandle):
+                continue
+            release_handle(handle)
+            domain_data.pop(key, None)
+    await hass.async_block_till_done()
+
+
+def release_handle(handle):
+    """Cancel timers and unsubscribe all listeners owned by a battery handle."""
+    if handle._pending_update_cancel is not None:
+        handle._pending_update_cancel()
+        handle._pending_update_cancel = None
+    for unsub in handle._listeners:
+        if unsub is not None:
+            unsub()
+    handle._listeners.clear()
+
+
+@pytest.fixture
+async def setup_battery(hass):
+    """Return a factory that sets up a battery_sim config entry."""
+
+    async def _setup(config=None, **entry_kwargs):
+        data = config or base_config()
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=data,
+            title=data["name"],
+            **entry_kwargs,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        return entry, hass.data[DOMAIN][entry.entry_id]
+
+    return _setup
+
+
+@pytest.fixture
+async def make_handle(hass, freezer):
+    """Return a factory creating bare battery handles with frozen time."""
+    handles = []
+
+    def _make(config=None):
+        handle = SimulatedBatteryHandle(config or base_config(), hass)
+        handles.append(handle)
+        return handle
+
+    yield _make
+
+    for handle in handles:
+        release_handle(handle)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,869 @@
+"""Tests for the core simulated battery logic in SimulatedBatteryHandle."""
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.core import Event
+
+from custom_components.battery_sim.const import (
+    ATTR_AVERAGE_ENERGY_VALUE,
+    ATTR_ENERGY_BATTERY_IN,
+    ATTR_ENERGY_BATTERY_OUT,
+    ATTR_ENERGY_SAVED,
+    ATTR_LAST_CHARGE_EFFICIENCY,
+    ATTR_LAST_DISCHARGE_EFFICIENCY,
+    ATTR_MONEY_SAVED,
+    ATTR_MONEY_SAVED_EXPORT,
+    ATTR_MONEY_SAVED_IMPORT,
+    ATTR_STATUS,
+    BATTERY_CYCLES,
+    BATTERY_DEGRADATION,
+    BATTERY_MODE,
+    CHARGE_ONLY,
+    CHARGING_RATE,
+    CONF_BATTERY_CHARGE_EFFICIENCY,
+    CONF_BATTERY_DISCHARGE_EFFICIENCY,
+    CONF_BATTERY_EFFICIENCY,
+    CONF_END_OF_LIFE_DEGRADATION,
+    CONF_EXPORT_SENSOR,
+    CONF_IMPORT_SENSOR,
+    CONF_INPUT_LIST,
+    CONF_MINIMUM_USER_SELECTABLE_SOC,
+    DISCHARGE_ONLY,
+    DISCHARGING_RATE,
+    FORCE_DISCHARGE,
+    GRID_EXPORT_SIM,
+    GRID_IMPORT_SIM,
+    MODE_CHARGING,
+    MODE_DISCHARGING,
+    MODE_EMPTY,
+    MODE_FORCE_CHARGING,
+    MODE_FORCE_DISCHARGING,
+    MODE_FULL,
+    MODE_IDLE,
+    NO_TARIFF_INFO,
+    OVERRIDE_CHARGING,
+    PAUSE_BATTERY,
+    SOLAR_POWER_CAP,
+    TARIFF_SENSOR,
+    TARIFF_TYPE,
+)
+
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from .common import (
+    EXPORT_SENSOR_ID,
+    EXPORT_TARIFF,
+    EXPORT_TARIFF_SENSOR_ID,
+    IMPORT_SENSOR_ID,
+    IMPORT_TARIFF,
+    IMPORT_TARIFF_SENSOR_ID,
+    KWH_ATTRIBUTES,
+    SOLAR_SENSOR_ID,
+    WH_ATTRIBUTES,
+    base_config,
+    config_with_fixed_tariffs,
+    config_with_solar,
+    config_with_tariff_sensors,
+    link_meter_readings,
+    rewind_last_update,
+)
+
+ONE_HOUR = 3600
+
+
+def update_after(handle, seconds, import_amount, export_amount, solar=0.0):
+    """Run a battery update pretending `seconds` have passed since the last."""
+    rewind_last_update(handle, seconds)
+    handle.update_battery(import_amount, export_amount, solar)
+
+
+class TestNormalMode:
+    """Battery behaviour in the default (self-consumption) mode."""
+
+    def test_initial_state(self, make_handle):
+        handle = make_handle()
+        assert handle.name == "test_battery"
+        assert handle._charge_state == 5.0
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+        assert handle._sensors[ATTR_STATUS] == "Normal"
+        assert handle._sensors[ATTR_LAST_CHARGE_EFFICIENCY] == 0.8
+        assert handle._sensors[ATTR_LAST_DISCHARGE_EFFICIENCY] == 0.9
+
+    def test_charges_from_export(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        assert handle._charge_state == pytest.approx(5.0 + 2.0 * 0.8)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(2.0)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == 0.0
+        assert handle._sensors[CHARGING_RATE] == pytest.approx(2.0)
+        assert handle._sensors[DISCHARGING_RATE] == 0.0
+        assert handle._sensors[BATTERY_MODE] == MODE_CHARGING
+        assert handle._sensors[ATTR_LAST_CHARGE_EFFICIENCY] == pytest.approx(0.8)
+        assert handle._sensors[ATTR_LAST_DISCHARGE_EFFICIENCY] is None
+        # All exported energy went into the battery.
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(0.0)
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(0.0)
+        assert handle._sensors[BATTERY_CYCLES] == pytest.approx(0.2)
+        assert handle._charge_percentage == 66
+
+    def test_discharges_to_cover_import(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 2.0, 0.0)
+
+        assert handle._charge_state == pytest.approx(5.0 - 2.0 / 0.9)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(2.0)
+        assert handle._sensors[ATTR_ENERGY_SAVED] == pytest.approx(2.0)
+        assert handle._sensors[DISCHARGING_RATE] == pytest.approx(2.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_DISCHARGING
+        assert handle._sensors[ATTR_LAST_DISCHARGE_EFFICIENCY] == pytest.approx(0.9)
+        assert handle._sensors[ATTR_LAST_CHARGE_EFFICIENCY] is None
+        # All import was covered by the battery.
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(0.0)
+
+    def test_charge_limited_by_max_charge_rate(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 10.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(4.0)
+        assert handle._charge_state == pytest.approx(5.0 + 4.0 * 0.8)
+        # Excess export still leaves to the grid.
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(6.0)
+
+    def test_discharge_limited_by_capacity_and_efficiency(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 10.0, 0.0)
+
+        # Only 5 kWh stored: deliverable energy is 5 * 0.9 = 4.5 kWh.
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(4.5)
+        assert handle._charge_state == pytest.approx(0.0)
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(5.5)
+        assert handle._sensors[ATTR_STATUS] == MODE_EMPTY
+
+    def test_charge_clipped_when_nearly_full(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._charge_state = 9.5
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        # Remaining capacity 0.5 kWh divided by 0.8 charge efficiency.
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(0.625)
+        assert handle._charge_state == pytest.approx(10.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(1.375)
+        assert handle._sensors[ATTR_STATUS] == MODE_FULL
+
+    def test_rate_limits_scale_with_interval(self, make_handle):
+        handle = make_handle()
+        update_after(handle, ONE_HOUR / 2, 0.0, 5.0)
+
+        # Half an hour at 4 kW allows 2 kWh into the battery.
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(2.0)
+        assert handle._sensors[CHARGING_RATE] == pytest.approx(4.0)
+
+    def test_simultaneous_import_and_export(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 1.0, 2.0)
+
+        assert handle._charge_state == pytest.approx(5.0 + 2.0 * 0.8 - 1.0 / 0.9)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(2.0)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(1.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_CHARGING
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(0.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(0.0)
+
+    def test_unknown_charge_state_recovers_to_zero(self, make_handle):
+        handle = make_handle()
+        handle._charge_state = "unknown"
+        update_after(handle, ONE_HOUR, 0.0, 0.0)
+
+        assert handle._charge_state == pytest.approx(0.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+
+
+class TestBatteryModes:
+    """Behaviour of the user-selectable operating modes."""
+
+    def test_pause_via_switch(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._switches[PAUSE_BATTERY] = True
+        update_after(handle, ONE_HOUR, 3.0, 2.0)
+
+        assert handle._charge_state == pytest.approx(5.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+        assert handle._sensors[ATTR_ENERGY_SAVED] == pytest.approx(0.0)
+        # Grid flows pass through unchanged.
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(3.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(2.0)
+        assert handle._sensors[ATTR_LAST_CHARGE_EFFICIENCY] is None
+        assert handle._sensors[ATTR_LAST_DISCHARGE_EFFICIENCY] is None
+
+    def test_pause_via_mode_select(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._battery_mode = PAUSE_BATTERY
+        update_after(handle, ONE_HOUR, 3.0, 2.0)
+
+        assert handle._charge_state == pytest.approx(5.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+
+    def test_force_charge_draws_from_grid(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._battery_mode = OVERRIDE_CHARGING
+        update_after(handle, ONE_HOUR, 1.0, 0.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(4.0)
+        assert handle._charge_state == pytest.approx(5.0 + 4.0 * 0.8)
+        assert handle._sensors[BATTERY_MODE] == MODE_FORCE_CHARGING
+        # House import plus the full battery charge come from the grid.
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(5.0)
+        assert handle._sensors[ATTR_ENERGY_SAVED] == pytest.approx(-4.0)
+
+    def test_force_charge_idle_when_full(self, make_handle):
+        handle = make_handle()
+        handle._battery_mode = OVERRIDE_CHARGING
+        handle._charge_state = 10.0
+        update_after(handle, ONE_HOUR, 0.0, 0.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(0.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+
+    def test_force_discharge_exports_to_grid(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._battery_mode = FORCE_DISCHARGE
+        update_after(handle, ONE_HOUR, 1.0, 0.5)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(4.5)
+        assert handle._charge_state == pytest.approx(0.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_FORCE_DISCHARGING
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(0.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(4.0)
+        assert handle._sensors[ATTR_STATUS] == MODE_EMPTY
+
+    def test_force_discharge_idle_when_empty(self, make_handle):
+        handle = make_handle()
+        handle._battery_mode = FORCE_DISCHARGE
+        handle._charge_state = 0.0
+        update_after(handle, ONE_HOUR, 0.0, 0.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(0.0)
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+
+    def test_charge_only_mode_never_discharges(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._battery_mode = CHARGE_ONLY
+        update_after(handle, ONE_HOUR, 2.0, 1.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(1.0)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(0.0)
+        assert handle._charge_state == pytest.approx(5.0 + 1.0 * 0.8)
+        # Imports pass straight through to the grid.
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(2.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(0.0)
+
+    def test_discharge_only_mode_never_charges(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        handle._battery_mode = DISCHARGE_ONLY
+        update_after(handle, ONE_HOUR, 2.0, 1.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(0.0)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(2.0)
+        assert handle._charge_state == pytest.approx(5.0 - 2.0 / 0.9)
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(0.0)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(1.0)
+
+
+class TestSliderLimits:
+    """Behaviour of the charge/discharge limit and SoC sliders."""
+
+    def test_charge_limit_slider(self, make_handle):
+        handle = make_handle()
+        handle.set_slider_limit(1.0, "charge_limit")
+        update_after(handle, ONE_HOUR, 0.0, 5.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(1.0)
+
+    def test_discharge_limit_slider(self, make_handle):
+        handle = make_handle()
+        handle.set_slider_limit(0.5, "discharge_limit")
+        update_after(handle, ONE_HOUR, 5.0, 0.0)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(0.5)
+
+    def test_minimum_soc_limits_discharge(self, make_handle):
+        handle = make_handle()
+        handle.set_slider_limit(20.0, "minimum_soc")
+        update_after(handle, ONE_HOUR, 10.0, 0.0)
+
+        # Only the 3 kWh above the 20% floor may leave, at 0.9 efficiency.
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(2.7)
+        assert handle._charge_state == pytest.approx(2.0)
+        assert handle._charge_percentage == 20
+
+    def test_maximum_soc_limits_charge(self, make_handle):
+        handle = make_handle()
+        handle.set_slider_limit(80.0, "maximum_soc")
+        update_after(handle, ONE_HOUR, 0.0, 10.0)
+
+        assert handle._charge_state == pytest.approx(8.0)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(3.0 / 0.8)
+
+    def test_minimum_soc_clamped_to_configured_floor(self, make_handle):
+        handle = make_handle(
+            base_config(**{CONF_MINIMUM_USER_SELECTABLE_SOC: 0.1})
+        )
+        assert handle._minimum_soc == 10.0
+
+        handle.set_slider_limit(5.0, "minimum_soc")
+        assert handle._minimum_soc == 10.0
+
+        handle.set_slider_limit(25.0, "minimum_soc")
+        assert handle._minimum_soc == 25.0
+
+    def test_unknown_slider_key_logs_error(self, make_handle, caplog):
+        handle = make_handle()
+        handle.set_slider_limit(1.0, "bogus_key")
+        assert "Unknown slider type" in caplog.text
+
+
+class TestSolarLimits:
+    """Solar production cap and inverter power sharing."""
+
+    def test_solar_cap_limits_charging(self, make_handle):
+        handle = make_handle(config_with_solar())
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 5.0, solar=0.5)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(0.5)
+        assert handle._sensors[SOLAR_POWER_CAP] == pytest.approx(0.5)
+        assert handle._sensors[GRID_EXPORT_SIM] == pytest.approx(4.5)
+
+    def test_inverter_power_shared_with_solar_limits_discharge(self, make_handle):
+        handle = make_handle(config_with_solar(nominal_inverter_power=3.0))
+        update_after(handle, ONE_HOUR, 5.0, 0.0, solar=0.5)
+
+        # Inverter has 3.0 - 0.5 = 2.5 kW left for discharging.
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(2.5)
+        assert handle._sensors[DISCHARGING_RATE] == pytest.approx(2.5)
+
+    def test_solar_amount_ignored_without_solar_sensor(self, make_handle):
+        handle = make_handle()
+        update_after(handle, ONE_HOUR, 0.0, 5.0, solar=0.1)
+
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(4.0)
+        assert handle._sensors[SOLAR_POWER_CAP] == 0.0
+
+
+class TestTariffsAndSavings:
+    """Money saved and tariff lookup behaviour."""
+
+    def test_money_saved_on_import(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 2.0, 0.0)
+
+        assert handle._sensors[ATTR_MONEY_SAVED_IMPORT] == pytest.approx(
+            2.0 * IMPORT_TARIFF
+        )
+        assert handle._sensors[ATTR_MONEY_SAVED_EXPORT] == pytest.approx(0.0)
+        assert handle._sensors[ATTR_MONEY_SAVED] == pytest.approx(2.0 * IMPORT_TARIFF)
+
+    def test_export_revenue_lost_while_charging(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        assert handle._sensors[ATTR_MONEY_SAVED_EXPORT] == pytest.approx(
+            -2.0 * EXPORT_TARIFF
+        )
+        assert handle._sensors[ATTR_MONEY_SAVED] == pytest.approx(-2.0 * EXPORT_TARIFF)
+
+    def test_no_money_tracked_without_tariffs(self, make_handle):
+        handle = make_handle()
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 2.0, 0.0)
+
+        assert handle._sensors[ATTR_MONEY_SAVED_IMPORT] == 0.0
+        assert handle._sensors[ATTR_MONEY_SAVED_EXPORT] == 0.0
+        assert handle._sensors[ATTR_MONEY_SAVED] == 0.0
+
+    def test_get_tariff_information_fixed(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        assert handle.get_tariff_information(handle._inputs[0]) == IMPORT_TARIFF
+        assert handle.get_tariff_information(handle._inputs[1]) == EXPORT_TARIFF
+
+    def test_get_tariff_information_none_input(self, make_handle):
+        handle = make_handle()
+        assert handle.get_tariff_information(None) is None
+
+    def test_get_tariff_information_no_tariff_type(self, make_handle):
+        handle = make_handle()
+        assert handle.get_tariff_information(handle._inputs[0]) is None
+
+    def test_get_tariff_information_sensor(self, hass, make_handle):
+        handle = make_handle(config_with_tariff_sensors())
+        hass.states.async_set(IMPORT_TARIFF_SENSOR_ID, "0.25")
+        hass.states.async_set(EXPORT_TARIFF_SENSOR_ID, "unavailable")
+
+        assert handle.get_tariff_information(handle._inputs[0]) == pytest.approx(0.25)
+        # Unavailable tariff sensors yield no tariff.
+        assert handle.get_tariff_information(handle._inputs[1]) is None
+
+    def test_get_tariff_information_missing_or_short_sensor(self, make_handle):
+        handle = make_handle(config_with_tariff_sensors())
+        # No state set at all.
+        assert handle.get_tariff_information(handle._inputs[0]) is None
+
+        handle._inputs[0][TARIFF_SENSOR] = "x.y"
+        assert handle.get_tariff_information(handle._inputs[0]) is None
+
+        handle._inputs[0][TARIFF_SENSOR] = None
+        assert handle.get_tariff_information(handle._inputs[0]) is None
+
+
+class TestStoredEnergyValue:
+    """Monetary book value of the stored energy and its published average."""
+
+    def test_charging_from_export_prices_energy_at_export_tariff(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        assert handle._stored_energy_value == pytest.approx(2.0 * EXPORT_TARIFF)
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(0.2 / 6.6)
+
+    def test_forced_grid_charging_prices_energy_at_import_tariff(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        link_meter_readings(handle)
+        handle._battery_mode = OVERRIDE_CHARGING
+        update_after(handle, ONE_HOUR, 0.0, 0.0)
+
+        assert handle._stored_energy_value == pytest.approx(4.0 * IMPORT_TARIFF)
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(1.2 / 8.2)
+
+    def test_average_value_unchanged_by_discharge(self, make_handle):
+        handle = make_handle(config_with_fixed_tariffs())
+        link_meter_readings(handle)
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+        average_before = handle._sensors[ATTR_AVERAGE_ENERGY_VALUE]
+
+        update_after(handle, ONE_HOUR, 1.0, 0.0)
+
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(
+            average_before
+        )
+        assert handle._stored_energy_value == pytest.approx(
+            0.2 * (1.0 - (1.0 / 0.9) / 6.6)
+        )
+
+    def test_average_value_excludes_reserved_floor_energy(self, make_handle):
+        handle = make_handle(
+            config_with_fixed_tariffs(**{CONF_MINIMUM_USER_SELECTABLE_SOC: 0.1})
+        )
+        link_meter_readings(handle)
+        assert handle.non_dischargeable_capacity == pytest.approx(1.0)
+
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        # The charged 0.2 cycles degrade capacity (and hence the floor) by a
+        # few millionths of a kWh, so compare with an absolute tolerance.
+        assert handle.dischargeable_stored_energy == pytest.approx(
+            6.6 - 1.0, abs=1e-4
+        )
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(
+            0.2 / 5.6, abs=1e-5
+        )
+
+
+class TestDegradation:
+    """Cycle counting and capacity degradation."""
+
+    def test_degradation_factor_progression(self, make_handle):
+        handle = make_handle()
+        assert handle.degradation_factor == pytest.approx(1.0)
+        assert handle.current_max_capacity == pytest.approx(10.0)
+
+        handle._sensors[BATTERY_CYCLES] = 3000.0
+        assert handle.degradation_factor == pytest.approx(0.9)
+        assert handle.current_max_capacity == pytest.approx(9.0)
+
+        handle._sensors[BATTERY_CYCLES] = 6000.0
+        assert handle.degradation_factor == pytest.approx(0.8)
+
+        # Degradation never drops below the configured end-of-life value.
+        handle._sensors[BATTERY_CYCLES] = 9000.0
+        assert handle.degradation_factor == pytest.approx(0.8)
+
+    def test_custom_end_of_life_degradation(self, make_handle):
+        handle = make_handle(base_config(**{CONF_END_OF_LIFE_DEGRADATION: 0.5}))
+        handle._sensors[BATTERY_CYCLES] = 6000.0
+        assert handle.degradation_factor == pytest.approx(0.5)
+
+    def test_cycles_accumulate_from_charged_energy(self, make_handle):
+        handle = make_handle()
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+        assert handle._sensors[BATTERY_CYCLES] == pytest.approx(0.2)
+
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+        assert handle._sensors[BATTERY_CYCLES] == pytest.approx(0.4)
+        assert handle._sensors[BATTERY_DEGRADATION] == pytest.approx(
+            1.0 - 0.2 * (0.4 / 6000.0)
+        )
+
+
+class TestDirectStateChanges:
+    """Service-style direct changes of charge state, cycles and stored value."""
+
+    def test_set_battery_charge_state(self, make_handle):
+        handle = make_handle()
+        handle.async_set_battery_charge_state(7.0)
+        assert handle._charge_state == pytest.approx(7.0)
+
+        handle.async_set_battery_charge_state(-3.0)
+        assert handle._charge_state == 0.0
+
+        handle.async_set_battery_charge_state(50.0)
+        assert handle._charge_state == pytest.approx(10.0)
+
+    def test_set_charge_state_preserves_average_value(self, make_handle):
+        handle = make_handle()
+        handle._stored_energy_value = 1.0
+        handle._update_average_energy_value_sensor()
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(0.2)
+
+        handle.async_set_battery_charge_state(2.5)
+        assert handle._stored_energy_value == pytest.approx(0.5)
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(0.2)
+
+        handle.async_set_battery_charge_state(0.0)
+        assert handle._stored_energy_value == 0.0
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == 0.0
+
+    def test_raising_charge_from_zero_leaves_energy_unvalued(self, make_handle):
+        handle = make_handle()
+        handle.async_set_battery_charge_state(0.0)
+        handle.async_set_battery_charge_state(5.0)
+
+        assert handle._stored_energy_value == 0.0
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == 0.0
+
+    def test_set_battery_cycles_ages_battery(self, make_handle):
+        handle = make_handle()
+        handle.async_set_battery_cycles(3000.0)
+
+        assert handle._sensors[BATTERY_CYCLES] == 3000.0
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == pytest.approx(30000.0)
+        assert handle._sensors[BATTERY_DEGRADATION] == pytest.approx(0.9)
+        assert handle.current_max_capacity == pytest.approx(9.0)
+        # Charge state below the new capacity stays put.
+        assert handle._charge_state == pytest.approx(5.0)
+        assert handle._charge_percentage == 56
+
+    def test_set_battery_cycles_clips_charge_and_rescales_value(self, make_handle):
+        handle = make_handle()
+        handle._charge_state = 9.5
+        handle._stored_energy_value = 0.95
+        handle._update_average_energy_value_sensor()
+        average_before = handle._sensors[ATTR_AVERAGE_ENERGY_VALUE]
+
+        handle.async_set_battery_cycles(3000.0)
+
+        assert handle._charge_state == pytest.approx(9.0)
+        assert handle._stored_energy_value == pytest.approx(0.95 * 9.0 / 9.5)
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(
+            average_before
+        )
+
+    def test_set_stored_energy_value(self, make_handle):
+        handle = make_handle()
+        handle.async_set_stored_energy_value(3.0)
+
+        assert handle._stored_energy_value == 3.0
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == pytest.approx(0.6)
+
+    def test_get_efficiency(self, make_handle):
+        handle = make_handle(
+            base_config(**{CONF_BATTERY_CHARGE_EFFICIENCY: "0:0.8, 4:1.0"})
+        )
+        assert handle.get_efficiency("charge", 0.0) == pytest.approx(0.8)
+        assert handle.get_efficiency("charge", 2.0) == pytest.approx(0.9)
+        assert handle.get_efficiency("charge", 10.0) == pytest.approx(1.0)
+        assert handle.get_efficiency("discharge", 3.0) == pytest.approx(0.9)
+
+        with pytest.raises(ValueError):
+            handle.get_efficiency("bogus", 1.0)
+
+
+class TestEfficiencyCurves:
+    """Power-dependent efficiency curves applied during updates."""
+
+    def test_charge_uses_interpolated_efficiency(self, make_handle):
+        handle = make_handle(
+            base_config(**{CONF_BATTERY_CHARGE_EFFICIENCY: "0:0.8, 4:1.0"})
+        )
+        update_after(handle, ONE_HOUR, 0.0, 2.0)
+
+        # 2 kW charging power interpolates to 0.9 efficiency.
+        assert handle._sensors[ATTR_LAST_CHARGE_EFFICIENCY] == pytest.approx(0.9)
+        assert handle._charge_state == pytest.approx(5.0 + 2.0 * 0.9)
+
+    def test_discharge_uses_interpolated_efficiency(self, make_handle):
+        handle = make_handle(
+            base_config(**{CONF_BATTERY_DISCHARGE_EFFICIENCY: "0:1.0, 5:0.8"})
+        )
+        update_after(handle, ONE_HOUR, 2.0, 0.0)
+
+        assert handle._sensors[ATTR_LAST_DISCHARGE_EFFICIENCY] == pytest.approx(0.92)
+        assert handle._charge_state == pytest.approx(5.0 - 2.0 / 0.92)
+
+    def test_legacy_single_efficiency_applies_to_both_directions(self, make_handle):
+        config = base_config(**{CONF_BATTERY_EFFICIENCY: 0.85})
+        del config[CONF_BATTERY_CHARGE_EFFICIENCY]
+        del config[CONF_BATTERY_DISCHARGE_EFFICIENCY]
+        handle = make_handle(config)
+
+        assert handle._battery_charge_efficiency_curve == [(0.0, 0.85)]
+        assert handle._battery_discharge_efficiency_curve == [(0.0, 0.85)]
+
+
+class TestReset:
+    """Resetting the battery to its initial state."""
+
+    def test_reset_restores_initial_state(self, hass, make_handle):
+        hass.states.async_set(IMPORT_SENSOR_ID, "123.4", KWH_ATTRIBUTES)
+        hass.states.async_set(EXPORT_SENSOR_ID, "unavailable", KWH_ATTRIBUTES)
+
+        handle = make_handle()
+        handle._charge_state = 8.2
+        handle._stored_energy_value = 2.0
+        handle._sensors[ATTR_ENERGY_SAVED] = 7.0
+        handle._sensors[ATTR_ENERGY_BATTERY_IN] = 9.0
+        handle._sensors[ATTR_ENERGY_BATTERY_OUT] = 4.0
+        handle._sensors[ATTR_MONEY_SAVED] = 3.0
+        handle._sensors[BATTERY_MODE] = MODE_CHARGING
+
+        handle.async_reset_battery()
+
+        assert handle._charge_state == pytest.approx(5.0)
+        assert handle._charge_percentage == 50
+        assert handle._stored_energy_value == 0.0
+        assert handle._sensors[ATTR_ENERGY_SAVED] == 0.0
+        assert handle._sensors[ATTR_ENERGY_BATTERY_IN] == 0.0
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == 0.0
+        assert handle._sensors[ATTR_MONEY_SAVED] == 0.0
+        assert handle._sensors[ATTR_AVERAGE_ENERGY_VALUE] == 0.0
+        assert handle._sensors[BATTERY_MODE] == MODE_IDLE
+        assert handle._sensors[ATTR_STATUS] == "Normal"
+        assert handle._sensors[BATTERY_CYCLES] == 0.0
+        assert handle._sensors[BATTERY_DEGRADATION] == 1.0
+        # Simulated meters rebase onto the live readings where available.
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(123.4)
+        assert handle._sensors[GRID_EXPORT_SIM] == 0.0
+
+
+class TestMeterReadingHandlers:
+    """State-change driven accumulation of import/export/solar readings."""
+
+    async def test_import_readings_accumulate(self, hass, make_handle):
+        handle = make_handle()
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "12.5", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == pytest.approx(2.5)
+        assert handle._last_import_reading_sensor_data is handle._inputs[0]
+        # Readings accumulate without updating the battery immediately.
+        assert handle._charge_state == pytest.approx(5.0)
+
+    async def test_watt_hour_readings_converted(self, hass, make_handle):
+        handle = make_handle()
+        hass.states.async_set(EXPORT_SENSOR_ID, "10000", WH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(EXPORT_SENSOR_ID, "12500", WH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_export_reading == pytest.approx(2.5)
+
+    async def test_unsupported_unit_ignored(self, hass, make_handle, caplog):
+        handle = make_handle()
+        attributes = dict(KWH_ATTRIBUTES, **{"unit_of_measurement": "MJ"})
+        hass.states.async_set(IMPORT_SENSOR_ID, "5.0", attributes)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "7.0", attributes)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == 0.0
+        assert "Unsupported energy unit" in caplog.text
+
+    async def test_unavailable_transitions_ignored(self, hass, make_handle):
+        handle = make_handle()
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "unavailable", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "12.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == 0.0
+
+    async def test_unchanged_reading_ignored(self, hass, make_handle):
+        handle = make_handle()
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(
+            IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES, force_update=True
+        )
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == 0.0
+
+    async def test_decreasing_reading_rebases_simulated_sensor(
+        self, hass, make_handle
+    ):
+        handle = make_handle()
+        handle._sensors[GRID_IMPORT_SIM] = 9.0
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "3.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == 0.0
+        assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(3.0)
+        assert handle._sensors[DISCHARGING_RATE] == 0
+
+    async def test_unknown_sensor_logs_warning(self, make_handle, caplog):
+        handle = make_handle()
+        event = Event("state_changed", {"entity_id": "sensor.not_tracked"})
+        handle.async_reading_handler(event)
+
+        assert "not found in input sensors" in caplog.text
+        assert handle._accumulated_import_reading == 0.0
+
+    async def test_solar_readings_accumulate(self, hass, make_handle):
+        handle = make_handle(config_with_solar())
+        hass.states.async_set(SOLAR_SENSOR_ID, "5.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(SOLAR_SENSOR_ID, "5.4", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_solar_reading == pytest.approx(0.4)
+
+    async def test_solar_meter_reset_clears_accumulation(self, hass, make_handle):
+        handle = make_handle(config_with_solar())
+        hass.states.async_set(SOLAR_SENSOR_ID, "5.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(SOLAR_SENSOR_ID, "5.4", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(SOLAR_SENSOR_ID, "0.1", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_solar_reading == 0.0
+
+
+class TestUpdateScheduling:
+    """Periodic updates and the minimum update interval."""
+
+    async def test_periodic_update_applies_accumulated_readings(
+        self, hass, make_handle, freezer
+    ):
+        handle = make_handle()
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "12.5", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        freezer.tick(timedelta(hours=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert handle._accumulated_import_reading == 0.0
+        assert handle._charge_state == pytest.approx(5.0 - 2.5 / 0.9)
+        assert handle._sensors[ATTR_ENERGY_BATTERY_OUT] == pytest.approx(2.5)
+
+    async def test_trigger_update_within_minimum_interval_defers(
+        self, hass, make_handle, freezer
+    ):
+        handle = make_handle()
+        hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+        hass.states.async_set(IMPORT_SENSOR_ID, "12.5", KWH_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        # No time has passed since the handle was created, so the update
+        # must be deferred rather than applied.
+        handle.async_trigger_update()
+        assert handle._pending_update_cancel is not None
+        assert handle._accumulated_import_reading == pytest.approx(2.5)
+        assert handle._charge_state == pytest.approx(5.0)
+
+        # A second trigger while one is pending must not schedule another.
+        pending = handle._pending_update_cancel
+        handle.async_trigger_update()
+        assert handle._pending_update_cancel is pending
+
+        freezer.tick(timedelta(seconds=6))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert handle._pending_update_cancel is None
+        assert handle._accumulated_import_reading == 0.0
+        assert handle._charge_state < 5.0
+
+    async def test_trigger_update_after_minimum_interval_runs_immediately(
+        self, make_handle
+    ):
+        handle = make_handle()
+        handle._accumulated_import_reading = 1.0
+        rewind_last_update(handle, ONE_HOUR)
+
+        handle.async_trigger_update()
+
+        assert handle._pending_update_cancel is None
+        assert handle._accumulated_import_reading == 0.0
+        assert handle._charge_state == pytest.approx(5.0 - 1.0 / 0.9)
+
+
+class TestLegacyConfig:
+    """Backwards compatibility with YAML-era configurations."""
+
+    def test_inputs_generated_when_input_list_missing(self, make_handle):
+        config = base_config()
+        del config[CONF_INPUT_LIST]
+        config[CONF_IMPORT_SENSOR] = IMPORT_SENSOR_ID
+        config[CONF_EXPORT_SENSOR] = EXPORT_SENSOR_ID
+        config[TARIFF_TYPE] = NO_TARIFF_INFO
+
+        handle = make_handle(config)
+
+        assert len(handle._inputs) == 2
+        assert handle._inputs[0][TARIFF_TYPE] == NO_TARIFF_INFO
+        assert GRID_IMPORT_SIM in handle._sensors
+        assert GRID_EXPORT_SIM in handle._sensors
+
+    def test_device_identifier_matching(self, hass, freezer):
+        from custom_components.battery_sim import SimulatedBatteryHandle
+        from custom_components.battery_sim.const import DOMAIN
+
+        handle = SimulatedBatteryHandle(base_config(), hass, entry_id="entry-id-1")
+        try:
+            assert handle.device_identifier == (DOMAIN, "entry-id-1")
+            assert handle.matches_device_identifiers({(DOMAIN, "entry-id-1")})
+            # Devices created before entry ids were used match on the name.
+            assert handle.matches_device_identifiers({(DOMAIN, "test_battery")})
+            assert not handle.matches_device_identifiers({(DOMAIN, "other")})
+            assert not handle.matches_device_identifiers({("other", "entry-id-1")})
+        finally:
+            for unsub in handle._listeners:
+                unsub()
+            handle._listeners.clear()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,38 @@
+"""Tests for the battery_sim button platform."""
+import pytest
+
+from custom_components.battery_sim.const import (
+    ATTR_ENERGY_SAVED,
+    GRID_IMPORT_SIM,
+)
+
+from .common import (
+    EXPORT_SENSOR_ID,
+    IMPORT_SENSOR_ID,
+    KWH_ATTRIBUTES,
+    RESET_BUTTON_ID,
+)
+
+
+async def test_reset_button_created(hass, setup_battery):
+    await setup_battery()
+    assert hass.states.get(RESET_BUTTON_ID) is not None
+
+
+async def test_pressing_reset_button_resets_battery(hass, setup_battery):
+    hass.states.async_set(IMPORT_SENSOR_ID, "123.4", KWH_ATTRIBUTES)
+    hass.states.async_set(EXPORT_SENSOR_ID, "55.5", KWH_ATTRIBUTES)
+    _entry, handle = await setup_battery()
+
+    handle._charge_state = 8.2
+    handle._sensors[ATTR_ENERGY_SAVED] = 7.0
+
+    await hass.services.async_call(
+        "button", "press", {"entity_id": RESET_BUTTON_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert handle._charge_state == pytest.approx(5.0)
+    assert handle._sensors[ATTR_ENERGY_SAVED] == 0.0
+    # Simulated meters rebase onto the live readings.
+    assert handle._sensors[GRID_IMPORT_SIM] == pytest.approx(123.4)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,442 @@
+"""Tests for the battery_sim config and options flows."""
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.battery_sim.const import (
+    BATTERY_TYPE,
+    CONF_BATTERY_CHARGE_EFFICIENCY,
+    CONF_BATTERY_DISCHARGE_EFFICIENCY,
+    CONF_BATTERY_MAX_CHARGE_RATE,
+    CONF_BATTERY_MAX_DISCHARGE_RATE,
+    CONF_BATTERY_SIZE,
+    CONF_END_OF_LIFE_DEGRADATION,
+    CONF_INPUT_LIST,
+    CONF_MINIMUM_USER_SELECTABLE_SOC,
+    CONF_NOMINAL_INVERTER_POWER,
+    CONF_RATED_BATTERY_CYCLES,
+    CONF_SOLAR_ENERGY_SENSOR,
+    CONF_UNIQUE_NAME,
+    CONF_UPDATE_FREQUENCY,
+    DOMAIN,
+    EXPORT,
+    FIXED_TARIFF,
+    IMPORT,
+    NO_TARIFF_INFO,
+    SENSOR_ID,
+    SENSOR_TYPE,
+    TARIFF_SENSOR,
+    TARIFF_TYPE,
+)
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .common import (
+    EXPORT_SENSOR_ID,
+    IMPORT_SENSOR_ID,
+    IMPORT_TARIFF_SENSOR_ID,
+    base_config,
+)
+
+CUSTOM_BATTERY_INPUT = {
+    CONF_UNIQUE_NAME: "My Custom Battery",
+    CONF_BATTERY_SIZE: 11.0,
+    CONF_BATTERY_MAX_DISCHARGE_RATE: 6.0,
+    CONF_BATTERY_MAX_CHARGE_RATE: 5.0,
+    CONF_BATTERY_DISCHARGE_EFFICIENCY: "0.9",
+    CONF_BATTERY_CHARGE_EFFICIENCY: "0:0.85, 5:0.95",
+    CONF_RATED_BATTERY_CYCLES: 5000,
+    CONF_END_OF_LIFE_DEGRADATION: 0.7,
+    CONF_UPDATE_FREQUENCY: 30,
+    CONF_MINIMUM_USER_SELECTABLE_SOC: 0.05,
+}
+
+
+async def select_menu_option(hass, flow_id, option):
+    """Choose an option from a menu step."""
+    return await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": option}
+    )
+
+
+async def add_meter(hass, flow_id, meter_step, sensor_id, tariff_step, tariff_input):
+    """Walk through adding one meter including its tariff sub-flow."""
+    result = await select_menu_option(hass, flow_id, meter_step)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {SENSOR_ID: sensor_id}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "tariff_menu"
+
+    result = await select_menu_option(hass, flow_id, tariff_step)
+    if tariff_input is not None:
+        assert result["type"] is FlowResultType.FORM
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, tariff_input
+        )
+    return result
+
+
+async def test_user_flow_with_predefined_battery(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {BATTERY_TYPE: "Tesla Powerwall"}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "meter_menu"
+    # Both meter types are still missing, so the flow cannot finish yet.
+    assert "all_done" not in result["menu_options"]
+
+    flow_id = result["flow_id"]
+    result = await add_meter(
+        hass, flow_id, "add_import_meter", IMPORT_SENSOR_ID, "no_tariff_info", None
+    )
+    assert result["step_id"] == "meter_menu"
+    assert "all_done" not in result["menu_options"]
+
+    result = await add_meter(
+        hass,
+        flow_id,
+        "add_export_meter",
+        EXPORT_SENSOR_ID,
+        "fixed_tariff",
+        {FIXED_TARIFF: 0.15},
+    )
+    assert result["step_id"] == "meter_menu"
+    assert "all_done" in result["menu_options"]
+
+    result = await select_menu_option(hass, flow_id, "all_done")
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Tesla Powerwall"
+    data = result["data"]
+    assert data[CONF_NAME] == "Tesla Powerwall"
+    assert data[CONF_BATTERY_SIZE] == 13.5
+    assert len(data[CONF_INPUT_LIST]) == 2
+    import_input, export_input = data[CONF_INPUT_LIST]
+    assert import_input[SENSOR_TYPE] == IMPORT
+    assert import_input[SENSOR_ID] == IMPORT_SENSOR_ID
+    assert import_input[TARIFF_TYPE] == NO_TARIFF_INFO
+    assert export_input[SENSOR_TYPE] == EXPORT
+    assert export_input[TARIFF_TYPE] == FIXED_TARIFF
+    assert export_input[FIXED_TARIFF] == 0.15
+
+
+async def test_user_flow_aborts_for_duplicate_battery(hass):
+    MockConfigEntry(
+        domain=DOMAIN, data=base_config(), unique_id="Tesla Powerwall"
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {BATTERY_TYPE: "Tesla Powerwall"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_custom_battery_flow(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {BATTERY_TYPE: "Custom"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "custom"
+
+    flow_id = result["flow_id"]
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, dict(CUSTOM_BATTERY_INPUT)
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "meter_menu"
+
+    result = await add_meter(
+        hass,
+        flow_id,
+        "add_import_meter",
+        IMPORT_SENSOR_ID,
+        "tariff_sensor",
+        {TARIFF_SENSOR: IMPORT_TARIFF_SENSOR_ID},
+    )
+    result = await add_meter(
+        hass, flow_id, "add_export_meter", EXPORT_SENSOR_ID, "no_tariff_info", None
+    )
+    result = await select_menu_option(hass, flow_id, "all_done")
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    data = result["data"]
+    assert data[CONF_NAME] == "My Custom Battery"
+    assert data[CONF_BATTERY_SIZE] == 11.0
+    assert data[CONF_BATTERY_CHARGE_EFFICIENCY] == "0:0.85, 5:0.95"
+    assert CONF_SOLAR_ENERGY_SENSOR not in data
+    assert CONF_NOMINAL_INVERTER_POWER not in data
+    import_input = data[CONF_INPUT_LIST][0]
+    assert import_input[TARIFF_TYPE] == TARIFF_SENSOR
+    assert import_input[TARIFF_SENSOR] == IMPORT_TARIFF_SENSOR_ID
+
+
+async def test_custom_battery_flow_rejects_invalid_efficiency(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {BATTERY_TYPE: "Custom"}
+    )
+
+    bad_input = dict(CUSTOM_BATTERY_INPUT)
+    bad_input[CONF_BATTERY_DISCHARGE_EFFICIENCY] = "not a number"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], bad_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "custom"
+    assert result["errors"] == {CONF_BATTERY_DISCHARGE_EFFICIENCY: "invalid_input"}
+
+
+async def test_custom_battery_flow_with_solar(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {BATTERY_TYPE: "Custom"}
+    )
+
+    flow_id = result["flow_id"]
+    custom_input = dict(CUSTOM_BATTERY_INPUT)
+    custom_input[CONF_UNIQUE_NAME] = "Solar Custom Battery"
+    custom_input[CONF_SOLAR_ENERGY_SENSOR] = "sensor.solar_production"
+    custom_input[CONF_NOMINAL_INVERTER_POWER] = 3.6
+    result = await hass.config_entries.flow.async_configure(flow_id, custom_input)
+    assert result["type"] is FlowResultType.MENU
+
+    await add_meter(
+        hass, flow_id, "add_import_meter", IMPORT_SENSOR_ID, "no_tariff_info", None
+    )
+    await add_meter(
+        hass, flow_id, "add_export_meter", EXPORT_SENSOR_ID, "no_tariff_info", None
+    )
+    result = await select_menu_option(hass, flow_id, "all_done")
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SOLAR_ENERGY_SENSOR] == "sensor.solar_production"
+    assert result["data"][CONF_NOMINAL_INVERTER_POWER] == 3.6
+
+
+class TestOptionsFlow:
+    """Tests for the options flow."""
+
+    async def _start_options(self, hass, entry):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "init"
+        return result
+
+    async def test_main_params_update(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "main_params"}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_SIZE: 12.0,
+                CONF_BATTERY_MAX_CHARGE_RATE: 3.0,
+                CONF_BATTERY_MAX_DISCHARGE_RATE: 6.0,
+                CONF_BATTERY_DISCHARGE_EFFICIENCY: "0.95",
+                CONF_BATTERY_CHARGE_EFFICIENCY: "0:0.8, 4:0.9",
+                CONF_RATED_BATTERY_CYCLES: 4000,
+                CONF_END_OF_LIFE_DEGRADATION: 0.75,
+                CONF_UPDATE_FREQUENCY: 120,
+                CONF_MINIMUM_USER_SELECTABLE_SOC: 0.2,
+            },
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "init"
+        await hass.async_block_till_done()
+
+        assert entry.data[CONF_BATTERY_SIZE] == 12.0
+        assert entry.data[CONF_BATTERY_CHARGE_EFFICIENCY] == "0:0.8, 4:0.9"
+        assert entry.data[CONF_UPDATE_FREQUENCY] == 120
+        # The reload created a fresh handle with the new configuration.
+        new_handle = hass.data[DOMAIN][entry.entry_id]
+        assert new_handle._battery_size == 12.0
+
+    async def test_main_params_rejects_invalid_efficiency(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "main_params"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_SIZE: 12.0,
+                CONF_BATTERY_MAX_CHARGE_RATE: 3.0,
+                CONF_BATTERY_MAX_DISCHARGE_RATE: 6.0,
+                CONF_BATTERY_DISCHARGE_EFFICIENCY: "bogus",
+                CONF_BATTERY_CHARGE_EFFICIENCY: "0.9",
+                CONF_RATED_BATTERY_CYCLES: 4000,
+                CONF_END_OF_LIFE_DEGRADATION: 0.75,
+                CONF_UPDATE_FREQUENCY: 120,
+                CONF_MINIMUM_USER_SELECTABLE_SOC: 0.2,
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {
+            CONF_BATTERY_DISCHARGE_EFFICIENCY: "invalid_input"
+        }
+
+    async def test_add_import_meter(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+        flow_id = result["flow_id"]
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "input_sensors"}
+        )
+        assert result["type"] is FlowResultType.MENU
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "add_import_meter"}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {SENSOR_ID: "sensor.second_import_energy"}
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "tariff_menu"
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "tariff_sensor"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {TARIFF_SENSOR: IMPORT_TARIFF_SENSOR_ID}
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "init"
+        await hass.async_block_till_done()
+
+        inputs = entry.data[CONF_INPUT_LIST]
+        assert len(inputs) == 3
+        assert inputs[2][SENSOR_ID] == "sensor.second_import_energy"
+        assert inputs[2][SENSOR_TYPE] == IMPORT
+        assert inputs[2][TARIFF_SENSOR] == IMPORT_TARIFF_SENSOR_ID
+
+    async def test_delete_input(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+        flow_id = result["flow_id"]
+
+        await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "input_sensors"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "delete_input"}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {CONF_INPUT_LIST: IMPORT_SENSOR_ID}
+        )
+        assert result["type"] is FlowResultType.MENU
+        await hass.async_block_till_done()
+
+        inputs = entry.data[CONF_INPUT_LIST]
+        assert len(inputs) == 1
+        assert inputs[0][SENSOR_ID] == EXPORT_SENSOR_ID
+
+    async def test_edit_input_tariff(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+        flow_id = result["flow_id"]
+
+        await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "input_sensors"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "edit_input_tariff"}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {CONF_INPUT_LIST: IMPORT_SENSOR_ID}
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "tariff_menu"
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "fixed_tariff"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {FIXED_TARIFF: 0.42}
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "init"
+        await hass.async_block_till_done()
+
+        import_input = entry.data[CONF_INPUT_LIST][0]
+        assert import_input[TARIFF_TYPE] == FIXED_TARIFF
+        assert import_input[FIXED_TARIFF] == 0.42
+
+    async def test_delete_leftover_entities(self, hass, setup_battery, caplog):
+        entry, _handle = await setup_battery()
+        entity_registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry.entry_id)}
+        )
+        stale = entity_registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "test_battery - obsolete sensor",
+            config_entry=entry,
+            device_id=device.id,
+        )
+
+        result = await self._start_options(hass, entry)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "delete_leftover_entities"}
+        )
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "init"
+
+        assert entity_registry.async_get(stale.entity_id) is None
+        assert "Deleted leftover Battery Sim entities" in caplog.text
+
+    async def test_all_done_creates_options_entry(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        result = await self._start_options(hass, entry)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "all_done"}
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,419 @@
+"""Tests for battery_sim helper functions."""
+from types import SimpleNamespace
+
+import pytest
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.battery_sim.const import (
+    CONF_ENERGY_EXPORT_TARIFF,
+    CONF_ENERGY_IMPORT_TARIFF,
+    CONF_ENERGY_TARIFF,
+    CONF_EXPORT_SENSOR,
+    CONF_IMPORT_SENSOR,
+    CONF_SECOND_ENERGY_EXPORT_TARIFF,
+    CONF_SECOND_ENERGY_IMPORT_TARIFF,
+    CONF_SECOND_EXPORT_SENSOR,
+    CONF_SECOND_IMPORT_SENSOR,
+    CONF_SOLAR_ENERGY_SENSOR,
+    DOMAIN,
+    EXPORT,
+    FIXED_NUMERICAL_TARIFFS,
+    FIXED_TARIFF,
+    GRID_EXPORT_SIM,
+    GRID_IMPORT_SIM,
+    GRID_SECOND_EXPORT_SIM,
+    GRID_SECOND_IMPORT_SIM,
+    IMPORT,
+    NO_TARIFF_INFO,
+    SENSOR_ID,
+    SENSOR_TYPE,
+    SIMULATED_SENSOR,
+    SOLAR_POWER_CAP,
+    TARIFF_SENSOR,
+    TARIFF_TYPE,
+)
+from custom_components.battery_sim.helpers import (
+    battery_device_identifiers,
+    device_display_name,
+    expected_entity_unique_ids,
+    find_empty_battery_devices,
+    find_leftover_entity_registry_entries,
+    generate_input_list,
+    interpolate_efficiency,
+    parse_efficiency_curve,
+    purge_leftover_battery_registry_entries,
+    validate_efficiency_config,
+)
+
+from .common import BATTERY_NAME, base_config
+
+
+class TestParseEfficiencyCurve:
+    """Tests for parse_efficiency_curve."""
+
+    def test_float_value(self):
+        assert parse_efficiency_curve(0.95) == [(0.0, 0.95)]
+
+    def test_int_value(self):
+        assert parse_efficiency_curve(1) == [(0.0, 1.0)]
+
+    def test_numeric_string(self):
+        assert parse_efficiency_curve("0.85") == [(0.0, 0.85)]
+
+    def test_numeric_string_with_whitespace(self):
+        assert parse_efficiency_curve("  0.85  ") == [(0.0, 0.85)]
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve(None)
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve("   ")
+
+    def test_unparseable_text_raises(self):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve("not an efficiency")
+
+    @pytest.mark.parametrize("value", [1.5, -0.1, "1.2"])
+    def test_out_of_range_value_raises(self, value):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve(value)
+
+    def test_colon_separated_pairs(self):
+        assert parse_efficiency_curve("0:0.9, 5:0.95") == [(0.0, 0.9), (5.0, 0.95)]
+
+    def test_parenthesised_pairs(self):
+        assert parse_efficiency_curve("(0, 0.9), (5, 0.95)") == [
+            (0.0, 0.9),
+            (5.0, 0.95),
+        ]
+
+    def test_semicolon_separated_pairs(self):
+        assert parse_efficiency_curve("0:0.9; 5:0.95") == [(0.0, 0.9), (5.0, 0.95)]
+
+    def test_pairs_sorted_by_power(self):
+        assert parse_efficiency_curve("5:0.95, 0:0.9, 2:0.92") == [
+            (0.0, 0.9),
+            (2.0, 0.92),
+            (5.0, 0.95),
+        ]
+
+    def test_duplicate_power_last_value_wins(self):
+        assert parse_efficiency_curve("0:0.9, 0:0.8") == [(0.0, 0.8)]
+
+    def test_negative_power_raises(self):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve("-1:0.9, 5:0.95")
+
+    def test_curve_efficiency_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            parse_efficiency_curve("0:0.9, 5:1.5")
+
+
+class TestValidateEfficiencyConfig:
+    """Tests for validate_efficiency_config."""
+
+    @pytest.mark.parametrize("value", [0.9, "0.9", "0:0.8, 5:0.95"])
+    def test_valid_value_returned_unchanged(self, value):
+        assert validate_efficiency_config(value) == value
+
+    @pytest.mark.parametrize("value", [None, "", "bogus", 1.7])
+    def test_invalid_value_raises(self, value):
+        with pytest.raises(ValueError):
+            validate_efficiency_config(value)
+
+
+class TestInterpolateEfficiency:
+    """Tests for interpolate_efficiency."""
+
+    def test_single_point_is_constant(self):
+        curve = [(0.0, 0.9)]
+        assert interpolate_efficiency(curve, 0.0) == 0.9
+        assert interpolate_efficiency(curve, 100.0) == 0.9
+
+    def test_below_first_point_returns_first(self):
+        curve = [(2.0, 0.8), (5.0, 0.9)]
+        assert interpolate_efficiency(curve, 1.0) == 0.8
+
+    def test_above_last_point_returns_last(self):
+        curve = [(0.0, 0.8), (5.0, 0.9)]
+        assert interpolate_efficiency(curve, 50.0) == 0.9
+
+    def test_linear_interpolation_midpoint(self):
+        curve = [(0.0, 0.8), (10.0, 1.0)]
+        assert interpolate_efficiency(curve, 5.0) == pytest.approx(0.9)
+
+    def test_exact_curve_points(self):
+        curve = [(0.0, 0.8), (4.0, 0.9), (8.0, 0.7)]
+        assert interpolate_efficiency(curve, 0.0) == 0.8
+        assert interpolate_efficiency(curve, 4.0) == pytest.approx(0.9)
+        assert interpolate_efficiency(curve, 8.0) == pytest.approx(0.7)
+
+    def test_interpolation_across_segments(self):
+        curve = [(0.0, 0.8), (4.0, 0.9), (8.0, 0.7)]
+        assert interpolate_efficiency(curve, 2.0) == pytest.approx(0.85)
+        assert interpolate_efficiency(curve, 6.0) == pytest.approx(0.8)
+
+    def test_empty_curve_raises(self):
+        with pytest.raises(ValueError):
+            interpolate_efficiency([], 1.0)
+
+
+class TestGenerateInputList:
+    """Tests for the legacy-config input list generation."""
+
+    BASE = {
+        CONF_IMPORT_SENSOR: "sensor.import_energy",
+        CONF_EXPORT_SENSOR: "sensor.export_energy",
+    }
+
+    def test_basic_import_and_export(self):
+        inputs = generate_input_list(dict(self.BASE))
+        assert len(inputs) == 2
+        assert inputs[0] == {
+            SENSOR_ID: "sensor.import_energy",
+            SENSOR_TYPE: IMPORT,
+            SIMULATED_SENSOR: GRID_IMPORT_SIM,
+            TARIFF_TYPE: TARIFF_SENSOR,
+        }
+        assert inputs[1] == {
+            SENSOR_ID: "sensor.export_energy",
+            SENSOR_TYPE: EXPORT,
+            SIMULATED_SENSOR: GRID_EXPORT_SIM,
+            TARIFF_TYPE: TARIFF_SENSOR,
+        }
+
+    def test_no_tariff_info_type(self):
+        config = dict(self.BASE)
+        config[TARIFF_TYPE] = NO_TARIFF_INFO
+        inputs = generate_input_list(config)
+        assert all(entry[TARIFF_TYPE] == NO_TARIFF_INFO for entry in inputs)
+
+    def test_fixed_tariffs(self):
+        config = dict(self.BASE)
+        config[TARIFF_TYPE] = FIXED_NUMERICAL_TARIFFS
+        config[CONF_ENERGY_IMPORT_TARIFF] = 0.3
+        config[CONF_ENERGY_EXPORT_TARIFF] = 0.1
+        inputs = generate_input_list(config)
+        assert inputs[0][TARIFF_TYPE] == FIXED_TARIFF
+        assert inputs[0][FIXED_TARIFF] == 0.3
+        assert inputs[1][FIXED_TARIFF] == 0.1
+
+    def test_tariff_sensors(self):
+        config = dict(self.BASE)
+        config[CONF_ENERGY_IMPORT_TARIFF] = "sensor.import_price"
+        config[CONF_ENERGY_EXPORT_TARIFF] = "sensor.export_price"
+        inputs = generate_input_list(config)
+        assert inputs[0][TARIFF_SENSOR] == "sensor.import_price"
+        assert inputs[1][TARIFF_SENSOR] == "sensor.export_price"
+
+    def test_legacy_energy_tariff_used_for_import(self):
+        config = dict(self.BASE)
+        config[CONF_ENERGY_TARIFF] = "sensor.legacy_price"
+        inputs = generate_input_list(config)
+        assert inputs[0][TARIFF_SENSOR] == "sensor.legacy_price"
+        assert TARIFF_SENSOR not in inputs[1]
+
+    def test_second_import_and_export_sensors(self):
+        config = dict(self.BASE)
+        config[CONF_SECOND_IMPORT_SENSOR] = "sensor.import_energy_2"
+        config[CONF_SECOND_EXPORT_SENSOR] = "sensor.export_energy_2"
+        config[CONF_SECOND_ENERGY_IMPORT_TARIFF] = "sensor.import_price_2"
+        config[CONF_SECOND_ENERGY_EXPORT_TARIFF] = "sensor.export_price_2"
+        inputs = generate_input_list(config)
+        assert len(inputs) == 4
+        assert inputs[2][SIMULATED_SENSOR] == GRID_SECOND_IMPORT_SIM
+        assert inputs[2][SENSOR_TYPE] == IMPORT
+        assert inputs[2][TARIFF_SENSOR] == "sensor.import_price_2"
+        assert inputs[3][SIMULATED_SENSOR] == GRID_SECOND_EXPORT_SIM
+        assert inputs[3][SENSOR_TYPE] == EXPORT
+        assert inputs[3][TARIFF_SENSOR] == "sensor.export_price_2"
+
+    def test_short_second_sensor_values_ignored(self):
+        config = dict(self.BASE)
+        config[CONF_SECOND_IMPORT_SENSOR] = ""
+        config[CONF_SECOND_EXPORT_SENSOR] = "x.y"
+        inputs = generate_input_list(config)
+        assert len(inputs) == 2
+
+
+class TestExpectedEntityUniqueIds:
+    """Tests for expected_entity_unique_ids."""
+
+    def test_contains_battery_and_all_per_input_sensors(self):
+        unique_ids = expected_entity_unique_ids(base_config())
+        assert BATTERY_NAME in unique_ids
+        assert f"{BATTERY_NAME} - total energy saved" in unique_ids
+        assert f"{BATTERY_NAME} - {GRID_IMPORT_SIM}" in unique_ids
+        assert f"{BATTERY_NAME} - {GRID_EXPORT_SIM}" in unique_ids
+        assert f"{BATTERY_NAME} - Battery Mode" in unique_ids
+        assert f"{BATTERY_NAME} - charge_limit" in unique_ids
+        # battery + 14 base sensors + 2 inputs + 7 control entities
+        assert len(unique_ids) == 24
+
+    def test_solar_config_adds_solar_power_cap(self):
+        config = base_config()
+        config[CONF_SOLAR_ENERGY_SENSOR] = "sensor.solar"
+        unique_ids = expected_entity_unique_ids(config)
+        assert f"{BATTERY_NAME} - {SOLAR_POWER_CAP}" in unique_ids
+        assert len(unique_ids) == 25
+
+    def test_no_solar_excludes_solar_power_cap(self):
+        unique_ids = expected_entity_unique_ids(base_config())
+        assert f"{BATTERY_NAME} - {SOLAR_POWER_CAP}" not in unique_ids
+
+    def test_legacy_config_without_input_list(self):
+        config = {
+            CONF_NAME: "legacy",
+            CONF_IMPORT_SENSOR: "sensor.import_energy",
+            CONF_EXPORT_SENSOR: "sensor.export_energy",
+        }
+        unique_ids = expected_entity_unique_ids(config)
+        assert f"legacy - {GRID_IMPORT_SIM}" in unique_ids
+        assert f"legacy - {GRID_EXPORT_SIM}" in unique_ids
+
+
+def test_battery_device_identifiers_without_entry_id():
+    assert battery_device_identifiers(base_config()) == [(DOMAIN, BATTERY_NAME)]
+
+
+def test_battery_device_identifiers_with_entry_id():
+    assert battery_device_identifiers(base_config(), "entry123") == [
+        (DOMAIN, "entry123"),
+        (DOMAIN, BATTERY_NAME),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name_by_user", "name", "expected"),
+    [
+        ("Renamed", "Original", "Renamed"),
+        (None, "Original", "Original"),
+        (None, None, "device-id"),
+    ],
+)
+def test_device_display_name(name_by_user, name, expected):
+    device = SimpleNamespace(name_by_user=name_by_user, name=name, id="device-id")
+    assert device_display_name(device) == expected
+
+
+class TestRegistryCleanupHelpers:
+    """Tests for leftover entity and empty device detection/purging."""
+
+    async def _setup_with_leftovers(self, hass, setup_battery):
+        """Set up a battery and add a stale entity plus an empty legacy device."""
+        entry, _handle = await setup_battery()
+        entity_registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry.entry_id)}
+        )
+        assert device is not None
+
+        stale = entity_registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"{BATTERY_NAME} - obsolete sensor",
+            config_entry=entry,
+            device_id=device.id,
+        )
+        # An entity from another integration must never be touched.
+        foreign = entity_registry.async_get_or_create(
+            "sensor",
+            "template",
+            "unrelated unique id",
+            device_id=device.id,
+        )
+        legacy_device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, BATTERY_NAME)},
+            name="legacy device",
+        )
+        return entry, entity_registry, device_registry, stale, foreign, legacy_device
+
+    async def test_no_leftovers_for_clean_setup(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        entity_registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
+        assert (
+            find_leftover_entity_registry_entries(
+                entity_registry, device_registry, entry.data, entry.entry_id
+            )
+            == []
+        )
+        assert (
+            find_empty_battery_devices(
+                entity_registry, device_registry, entry.data, entry.entry_id
+            )
+            == []
+        )
+
+    async def test_find_leftover_entities(self, hass, setup_battery):
+        (
+            entry,
+            entity_registry,
+            device_registry,
+            stale,
+            _foreign,
+            _legacy_device,
+        ) = await self._setup_with_leftovers(hass, setup_battery)
+
+        leftovers = find_leftover_entity_registry_entries(
+            entity_registry, device_registry, entry.data, entry.entry_id
+        )
+        assert [entry_.entity_id for entry_ in leftovers] == [stale.entity_id]
+
+    async def test_find_empty_devices(self, hass, setup_battery):
+        (
+            entry,
+            entity_registry,
+            device_registry,
+            _stale,
+            _foreign,
+            legacy_device,
+        ) = await self._setup_with_leftovers(hass, setup_battery)
+
+        empty = find_empty_battery_devices(
+            entity_registry, device_registry, entry.data, entry.entry_id
+        )
+        assert [device.id for device in empty] == [legacy_device.id]
+
+    async def test_purge_removes_stale_entity_and_empty_device(
+        self, hass, setup_battery
+    ):
+        (
+            entry,
+            entity_registry,
+            device_registry,
+            stale,
+            foreign,
+            legacy_device,
+        ) = await self._setup_with_leftovers(hass, setup_battery)
+
+        removed_entities, removed_devices = purge_leftover_battery_registry_entries(
+            entity_registry, device_registry, entry.data, entry.entry_id
+        )
+
+        assert removed_entities == [stale.entity_id]
+        assert removed_devices == ["legacy device"]
+        assert entity_registry.async_get(stale.entity_id) is None
+        assert entity_registry.async_get(foreign.entity_id) is not None
+        assert device_registry.async_get(legacy_device.id) is None
+        # The active battery device and its entities stay untouched.
+        assert (
+            device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+            is not None
+        )
+        assert entity_registry.async_get("sensor.test_battery") is not None
+
+    async def test_purge_with_nothing_to_remove(self, hass, setup_battery):
+        entry, _handle = await setup_battery()
+        removed_entities, removed_devices = purge_leftover_battery_registry_entries(
+            er.async_get(hass), dr.async_get(hass), entry.data, entry.entry_id
+        )
+        assert removed_entities == []
+        assert removed_devices == []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,258 @@
+"""Tests for battery_sim setup, unload and services."""
+import pytest
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from custom_components.battery_sim.const import (
+    CONF_BATTERY_EFFICIENCY,
+    CONF_BATTERY_MAX_CHARGE_RATE,
+    CONF_BATTERY_MAX_DISCHARGE_RATE,
+    CONF_BATTERY_SIZE,
+    CONF_EXPORT_SENSOR,
+    CONF_IMPORT_SENSOR,
+    DOMAIN,
+)
+
+from .common import BATTERY_NAME, base_config
+
+SERVICES = (
+    "set_battery_charge_state",
+    "set_battery_cycles",
+    "get_efficiency",
+    "set_stored_energy_value",
+)
+
+
+def get_battery_device(hass, entry):
+    """Return the device registry entry created for a battery config entry."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    return device
+
+
+async def test_setup_entry_creates_handle_and_services(hass, setup_battery):
+    entry, handle = await setup_battery()
+
+    assert hass.data[DOMAIN][entry.entry_id] is handle
+    assert handle.name == BATTERY_NAME
+    for service in SERVICES:
+        assert hass.services.has_service(DOMAIN, service)
+
+
+async def test_unload_entry_removes_handle_and_services(hass, setup_battery):
+    entry, _handle = await setup_battery()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert DOMAIN not in hass.data
+    for service in SERVICES:
+        assert not hass.services.has_service(DOMAIN, service)
+
+
+async def test_services_persist_until_last_entry_unloaded(hass, setup_battery):
+    entry_one, _ = await setup_battery()
+    second_config = base_config(**{CONF_NAME: "second_battery"})
+    entry_two, _ = await setup_battery(second_config)
+
+    assert await hass.config_entries.async_unload(entry_one.entry_id)
+    await hass.async_block_till_done()
+    for service in SERVICES:
+        assert hass.services.has_service(DOMAIN, service)
+
+    assert await hass.config_entries.async_unload(entry_two.entry_id)
+    await hass.async_block_till_done()
+    for service in SERVICES:
+        assert not hass.services.has_service(DOMAIN, service)
+
+
+async def test_set_battery_charge_state_service(hass, setup_battery):
+    entry, handle = await setup_battery()
+    device = get_battery_device(hass, entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_battery_charge_state",
+        {"device_id": device.id, "charge_state": 7.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._charge_state == pytest.approx(7.5)
+
+
+async def test_set_battery_charge_state_unknown_device(
+    hass, setup_battery, caplog
+):
+    _entry, handle = await setup_battery()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_battery_charge_state",
+        {"device_id": "no-such-device", "charge_state": 7.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._charge_state == pytest.approx(5.0)
+    assert "Device not found" in caplog.text
+
+
+async def test_set_battery_charge_state_unmatched_device(
+    hass, setup_battery, caplog
+):
+    entry, handle = await setup_battery()
+    device_registry = dr.async_get(hass)
+    unrelated = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("other_domain", "other_device")},
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_battery_charge_state",
+        {"device_id": unrelated.id, "charge_state": 7.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._charge_state == pytest.approx(5.0)
+    assert "No handle matched" in caplog.text
+
+
+async def test_set_battery_cycles_service(hass, setup_battery):
+    entry, handle = await setup_battery()
+    device = get_battery_device(hass, entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_battery_cycles",
+        {"device_id": device.id, "battery_cycles": 3000},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._sensors["battery_cycles"] == pytest.approx(3000.0)
+    assert handle.current_max_capacity == pytest.approx(9.0)
+
+
+async def test_set_stored_energy_value_service(hass, setup_battery):
+    entry, handle = await setup_battery()
+    device = get_battery_device(hass, entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_stored_energy_value",
+        {"device_id": device.id, "stored_energy_value": 1.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._stored_energy_value == pytest.approx(1.5)
+
+
+async def test_get_efficiency_service(hass, setup_battery):
+    entry, _handle = await setup_battery()
+    device = get_battery_device(hass, entry)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "get_efficiency",
+        {"device_id": device.id, "efficiency_type": "charge", "power_level": 2.0},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["success"] is True
+    assert response["battery"] == BATTERY_NAME
+    assert response["efficiency"] == pytest.approx(0.8)
+
+
+async def test_get_efficiency_service_discharge(hass, setup_battery):
+    entry, _handle = await setup_battery()
+    device = get_battery_device(hass, entry)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "get_efficiency",
+        {"device_id": device.id, "efficiency_type": "discharge", "power_level": 1.0},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["efficiency"] == pytest.approx(0.9)
+
+
+async def test_get_efficiency_service_unknown_device(hass, setup_battery):
+    await setup_battery()
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "get_efficiency",
+        {
+            "device_id": "no-such-device",
+            "efficiency_type": "charge",
+            "power_level": 2.0,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["success"] is False
+    assert "No simulated battery found" in response["error"]
+
+
+async def test_yaml_setup_creates_handle_and_entities(hass):
+    yaml_config = {
+        DOMAIN: {
+            "my_battery": {
+                CONF_NAME: "my_battery",
+                CONF_IMPORT_SENSOR: "sensor.yaml_import_energy",
+                CONF_EXPORT_SENSOR: "sensor.yaml_export_energy",
+                CONF_BATTERY_SIZE: 8.0,
+                CONF_BATTERY_MAX_DISCHARGE_RATE: 3.0,
+                CONF_BATTERY_MAX_CHARGE_RATE: 2.0,
+                CONF_BATTERY_EFFICIENCY: 0.9,
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, yaml_config)
+    await hass.async_block_till_done()
+
+    handle = hass.data[DOMAIN]["my_battery"]
+    assert handle.name == "my_battery"
+    assert handle._battery_size == 8.0
+    # Discovery created the platform entities.
+    assert hass.states.get("sensor.my_battery") is not None
+    assert hass.states.get("switch.my_battery_pause_battery") is not None
+    assert hass.states.get("select.my_battery_battery_mode") is not None
+
+
+async def test_yaml_setup_without_domain_config(hass):
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert hass.data[DOMAIN] == {}
+
+
+async def test_leftover_entities_logged_on_setup(hass, setup_battery, caplog):
+    entry, _handle = await setup_battery()
+    entity_registry = er.async_get(hass)
+    device = get_battery_device(hass, entry)
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{BATTERY_NAME} - obsolete sensor",
+        config_entry=entry,
+        device_id=device.id,
+    )
+
+    caplog.clear()
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "has leftover entities" in caplog.text

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,132 @@
+"""Tests for the battery_sim number platform."""
+import pytest
+
+from homeassistant.core import State
+
+from custom_components.battery_sim.const import CONF_MINIMUM_USER_SELECTABLE_SOC
+
+from pytest_homeassistant_custom_component.common import (
+    mock_restore_cache_with_extra_data,
+)
+
+from .common import (
+    CHARGE_LIMIT_NUMBER_ID,
+    DISCHARGE_LIMIT_NUMBER_ID,
+    MAXIMUM_SOC_NUMBER_ID,
+    MINIMUM_SOC_NUMBER_ID,
+    base_config,
+)
+
+
+def restore_data(entity_id, value, minimum=0.0, maximum=100.0, step=0.01, unit="kW"):
+    """Build a RestoreNumber cache record."""
+    return (
+        State(entity_id, str(value)),
+        {
+            "native_max_value": maximum,
+            "native_min_value": minimum,
+            "native_step": step,
+            "native_unit_of_measurement": unit,
+            "native_value": value,
+        },
+    )
+
+
+async def set_number(hass, entity_id, value):
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": entity_id, "value": value},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_sliders_created_with_expected_ranges(hass, setup_battery):
+    await setup_battery()
+
+    charge_limit = hass.states.get(CHARGE_LIMIT_NUMBER_ID)
+    assert charge_limit.state == "4.0"
+    assert charge_limit.attributes["max"] == 4.0
+    assert charge_limit.attributes["min"] == 0.0
+
+    discharge_limit = hass.states.get(DISCHARGE_LIMIT_NUMBER_ID)
+    assert discharge_limit.state == "5.0"
+    assert discharge_limit.attributes["max"] == 5.0
+
+    minimum_soc = hass.states.get(MINIMUM_SOC_NUMBER_ID)
+    assert minimum_soc.state == "0.0"
+    assert minimum_soc.attributes["max"] == 100.0
+
+    maximum_soc = hass.states.get(MAXIMUM_SOC_NUMBER_ID)
+    # The slider is initialised with the integer 100, so no decimal is shown.
+    assert maximum_soc.state == "100"
+
+
+async def test_minimum_soc_slider_floor_from_config(hass, setup_battery):
+    await setup_battery(base_config(**{CONF_MINIMUM_USER_SELECTABLE_SOC: 0.1}))
+
+    minimum_soc = hass.states.get(MINIMUM_SOC_NUMBER_ID)
+    assert minimum_soc.state == "10.0"
+    assert minimum_soc.attributes["min"] == 10.0
+
+
+async def test_setting_sliders_updates_handle(hass, setup_battery):
+    _entry, handle = await setup_battery()
+
+    await set_number(hass, CHARGE_LIMIT_NUMBER_ID, 2.5)
+    assert handle._charge_limit == 2.5
+
+    await set_number(hass, DISCHARGE_LIMIT_NUMBER_ID, 1.5)
+    assert handle._discharge_limit == 1.5
+
+    await set_number(hass, MINIMUM_SOC_NUMBER_ID, 20)
+    assert handle._minimum_soc == 20
+
+    await set_number(hass, MAXIMUM_SOC_NUMBER_ID, 80)
+    assert handle._maximum_soc == 80
+
+
+async def test_minimum_soc_clamped_to_configured_floor(hass, setup_battery):
+    _entry, handle = await setup_battery(
+        base_config(**{CONF_MINIMUM_USER_SELECTABLE_SOC: 0.1})
+    )
+
+    entity = hass.data["entity_components"]["number"].get_entity(
+        MINIMUM_SOC_NUMBER_ID
+    )
+    await entity.async_set_native_value(5.0)
+    await hass.async_block_till_done()
+
+    assert handle._minimum_soc == 10.0
+    assert hass.states.get(MINIMUM_SOC_NUMBER_ID).state == "10.0"
+
+
+async def test_restore_slider_values(hass, setup_battery):
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            restore_data(CHARGE_LIMIT_NUMBER_ID, 2.0, maximum=4.0),
+            restore_data(DISCHARGE_LIMIT_NUMBER_ID, 1.0, maximum=5.0),
+            restore_data(MAXIMUM_SOC_NUMBER_ID, 90.0, step=1, unit="%"),
+        ),
+    )
+    _entry, handle = await setup_battery()
+
+    assert handle._charge_limit == pytest.approx(2.0)
+    assert handle._discharge_limit == pytest.approx(1.0)
+    assert handle._maximum_soc == pytest.approx(90.0)
+    assert hass.states.get(CHARGE_LIMIT_NUMBER_ID).state == "2.0"
+
+
+async def test_restored_minimum_soc_clamped_to_floor(hass, setup_battery):
+    mock_restore_cache_with_extra_data(
+        hass,
+        (restore_data(MINIMUM_SOC_NUMBER_ID, 5.0, step=1, unit="%"),),
+    )
+    _entry, handle = await setup_battery(
+        base_config(**{CONF_MINIMUM_USER_SELECTABLE_SOC: 0.1})
+    )
+
+    assert handle._minimum_soc == pytest.approx(10.0)
+    assert hass.states.get(MINIMUM_SOC_NUMBER_ID).state == "10.0"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,71 @@
+"""Tests for the battery_sim select platform."""
+from custom_components.battery_sim.const import (
+    DEFAULT_MODE,
+    FORCE_DISCHARGE,
+    OVERRIDE_CHARGING,
+    PAUSE_BATTERY,
+)
+
+from .common import MODE_SELECT_ID
+
+
+async def test_mode_select_created_with_options(hass, setup_battery):
+    await setup_battery()
+
+    state = hass.states.get(MODE_SELECT_ID)
+    assert state is not None
+    assert state.state == "Default mode"
+    assert state.attributes["options"] == [
+        "Default mode",
+        "Force charge",
+        "Pause battery",
+        "Force discharge",
+        "Charge only",
+        "Discharge only",
+    ]
+
+
+async def test_selecting_mode_updates_handle(hass, setup_battery):
+    _entry, handle = await setup_battery()
+    assert handle._battery_mode == DEFAULT_MODE
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": MODE_SELECT_ID, "option": "Force charge"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._battery_mode == OVERRIDE_CHARGING
+    assert hass.states.get(MODE_SELECT_ID).state == "Force charge"
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": MODE_SELECT_ID, "option": "Force discharge"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._battery_mode == FORCE_DISCHARGE
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": MODE_SELECT_ID, "option": "Pause battery"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert handle._battery_mode == PAUSE_BATTERY
+
+
+async def test_invalid_option_is_ignored(hass, setup_battery, caplog):
+    _entry, handle = await setup_battery()
+
+    entity = hass.data["entity_components"]["select"].get_entity(MODE_SELECT_ID)
+    await entity.async_select_option("Not a real mode")
+
+    assert handle._battery_mode == DEFAULT_MODE
+    assert "Invalid option selected" in caplog.text

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,234 @@
+"""Tests for the battery_sim sensor platform."""
+import pytest
+
+from homeassistant.core import State
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.battery_sim.const import (
+    ATTR_CHARGE_PERCENTAGE,
+    ATTR_ENERGY_SAVED,
+    ATTR_MONEY_SAVED,
+    ATTR_STATUS,
+    ATTR_STORED_ENERGY_VALUE,
+    CONF_BATTERY_SIZE,
+    GRID_IMPORT_SIM,
+    MESSAGE_TYPE_BATTERY_UPDATE,
+    MODE_IDLE,
+    PERCENTAGE_ENERGY_IMPORT_SAVED,
+)
+
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from .common import (
+    AVERAGE_VALUE_SENSOR_ID,
+    BATTERY_ENTITY_ID,
+    BATTERY_MODE_SENSOR_ID,
+    BATTERY_NAME,
+    CHARGE_EFFICIENCY_SENSOR_ID,
+    CHARGING_RATE_SENSOR_ID,
+    CYCLES_SENSOR_ID,
+    DEGRADATION_SENSOR_ID,
+    DISCHARGE_EFFICIENCY_SENSOR_ID,
+    DISCHARGING_RATE_SENSOR_ID,
+    ENERGY_IN_SENSOR_ID,
+    ENERGY_OUT_SENSOR_ID,
+    ENERGY_SAVED_SENSOR_ID,
+    IMPORT_SENSOR_ID,
+    KWH_ATTRIBUTES,
+    MONEY_SAVED_EXPORT_SENSOR_ID,
+    MONEY_SAVED_IMPORT_SENSOR_ID,
+    MONEY_SAVED_SENSOR_ID,
+    SIM_EXPORT_SENSOR_ID,
+    SIM_IMPORT_SENSOR_ID,
+    SOLAR_CAP_SENSOR_ID,
+    config_with_solar,
+)
+
+
+def battery_update_signal():
+    return f"{BATTERY_NAME}-{MESSAGE_TYPE_BATTERY_UPDATE}"
+
+
+async def test_all_sensors_created_with_initial_values(hass, setup_battery):
+    await setup_battery()
+
+    expected_initial_states = {
+        BATTERY_ENTITY_ID: "5.0",
+        BATTERY_MODE_SENSOR_ID: MODE_IDLE,
+        ENERGY_SAVED_SENSOR_ID: "0.0",
+        ENERGY_IN_SENSOR_ID: "0.0",
+        ENERGY_OUT_SENSOR_ID: "0.0",
+        CHARGING_RATE_SENSOR_ID: "0.0",
+        DISCHARGING_RATE_SENSOR_ID: "0.0",
+        CHARGE_EFFICIENCY_SENSOR_ID: "0.8",
+        DISCHARGE_EFFICIENCY_SENSOR_ID: "0.9",
+        SIM_IMPORT_SENSOR_ID: "0.0",
+        SIM_EXPORT_SENSOR_ID: "0.0",
+        CYCLES_SENSOR_ID: "0.0",
+        DEGRADATION_SENSOR_ID: "1.0",
+        MONEY_SAVED_IMPORT_SENSOR_ID: "0.0",
+        MONEY_SAVED_SENSOR_ID: "0.0",
+        MONEY_SAVED_EXPORT_SENSOR_ID: "0.0",
+        AVERAGE_VALUE_SENSOR_ID: "0.0",
+    }
+    for entity_id, expected_state in expected_initial_states.items():
+        state = hass.states.get(entity_id)
+        assert state is not None, f"missing entity {entity_id}"
+        assert state.state == expected_state, f"unexpected state for {entity_id}"
+
+    # No solar sensor configured, so no solar power cap entity.
+    assert hass.states.get(SOLAR_CAP_SENSOR_ID) is None
+
+
+async def test_solar_power_cap_sensor_created_with_solar_config(
+    hass, setup_battery
+):
+    await setup_battery(config_with_solar())
+    assert hass.states.get(SOLAR_CAP_SENSOR_ID) is not None
+
+
+async def test_battery_sensor_attributes(hass, setup_battery):
+    await setup_battery()
+    state = hass.states.get(BATTERY_ENTITY_ID)
+
+    assert state.attributes[ATTR_STATUS] == MODE_IDLE
+    assert state.attributes[ATTR_CHARGE_PERCENTAGE] == 50
+    assert state.attributes[CONF_BATTERY_SIZE] == 10.0
+    assert IMPORT_SENSOR_ID in state.attributes["sources"]
+
+
+async def test_mode_sensor_attributes(hass, setup_battery):
+    await setup_battery()
+    state = hass.states.get(BATTERY_MODE_SENSOR_ID)
+
+    assert state.attributes[ATTR_STATUS] == "Normal"
+    assert state.attributes[ATTR_CHARGE_PERCENTAGE] == 50
+
+
+async def test_sensors_update_when_battery_updates(hass, setup_battery):
+    _entry, handle = await setup_battery()
+
+    handle._sensors[ATTR_ENERGY_SAVED] = 12.3456
+    handle._sensors[ATTR_MONEY_SAVED] = 1.23456
+    handle.async_set_battery_charge_state(7.5)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(BATTERY_ENTITY_ID).state == "7.5"
+    assert (
+        hass.states.get(BATTERY_ENTITY_ID).attributes[ATTR_CHARGE_PERCENTAGE] == 50
+    )
+    # Energy values round to 3 decimals, money to 2.
+    assert hass.states.get(ENERGY_SAVED_SENSOR_ID).state == "12.346"
+    assert hass.states.get(MONEY_SAVED_SENSOR_ID).state == "1.23"
+
+
+async def test_percentage_energy_saved_attribute(hass, setup_battery):
+    hass.states.async_set(IMPORT_SENSOR_ID, "10.0", KWH_ATTRIBUTES)
+    _entry, handle = await setup_battery()
+
+    handle._sensors[GRID_IMPORT_SIM] = 8.0
+    async_dispatcher_send(hass, battery_update_signal())
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SIM_IMPORT_SENSOR_ID)
+    assert state.state == "8.0"
+    assert state.attributes[PERCENTAGE_ENERGY_IMPORT_SAVED] == 20.0
+
+
+async def test_percentage_energy_saved_attribute_zero_import(
+    hass, setup_battery, caplog
+):
+    hass.states.async_set(IMPORT_SENSOR_ID, "0.0", KWH_ATTRIBUTES)
+    _entry, handle = await setup_battery()
+
+    handle._sensors[GRID_IMPORT_SIM] = 8.0
+    async_dispatcher_send(hass, battery_update_signal())
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SIM_IMPORT_SENSOR_ID)
+    assert state.attributes[PERCENTAGE_ENERGY_IMPORT_SAVED] == 0
+    assert "Division by zero" in caplog.text
+
+
+async def test_restore_battery_charge_state(hass, setup_battery):
+    mock_restore_cache(hass, [State(BATTERY_ENTITY_ID, "7.5")])
+    _entry, handle = await setup_battery()
+
+    assert handle._charge_state == pytest.approx(7.5)
+    assert hass.states.get(BATTERY_ENTITY_ID).state == "7.5"
+
+
+async def test_restore_battery_charge_clipped_to_capacity(hass, setup_battery):
+    mock_restore_cache(hass, [State(BATTERY_ENTITY_ID, "25.0")])
+    _entry, handle = await setup_battery()
+
+    assert handle._charge_state == pytest.approx(10.0)
+
+
+async def test_restore_display_sensor_value(hass, setup_battery):
+    mock_restore_cache(hass, [State(ENERGY_SAVED_SENSOR_ID, "12.345")])
+    _entry, handle = await setup_battery()
+
+    assert handle._sensors[ATTR_ENERGY_SAVED] == pytest.approx(12.345)
+    assert hass.states.get(ENERGY_SAVED_SENSOR_ID).state == "12.345"
+
+
+async def test_restore_invalid_states_ignored(hass, setup_battery):
+    mock_restore_cache(
+        hass,
+        [
+            State(BATTERY_ENTITY_ID, "unknown"),
+            State(ENERGY_SAVED_SENSOR_ID, "unavailable"),
+        ],
+    )
+    _entry, handle = await setup_battery()
+
+    assert handle._charge_state == pytest.approx(5.0)
+    assert handle._sensors[ATTR_ENERGY_SAVED] == 0.0
+
+
+async def test_restore_non_numeric_state_ignored(hass, setup_battery):
+    mock_restore_cache(hass, [State(ENERGY_SAVED_SENSOR_ID, "garbage")])
+    _entry, handle = await setup_battery()
+
+    assert handle._sensors[ATTR_ENERGY_SAVED] == 0.0
+
+
+async def test_restore_average_energy_value_with_stored_value_attribute(
+    hass, setup_battery
+):
+    mock_restore_cache(
+        hass,
+        [
+            State(BATTERY_ENTITY_ID, "5.0"),
+            State(
+                AVERAGE_VALUE_SENSOR_ID,
+                "0.25",
+                {ATTR_STORED_ENERGY_VALUE: 1.25},
+            ),
+        ],
+    )
+    _entry, handle = await setup_battery()
+
+    assert handle._stored_energy_value == pytest.approx(1.25)
+    state = hass.states.get(AVERAGE_VALUE_SENSOR_ID)
+    assert state.state == "0.25"
+    assert state.attributes[ATTR_STORED_ENERGY_VALUE] == pytest.approx(1.25)
+
+
+async def test_restore_legacy_average_energy_value_without_attribute(
+    hass, setup_battery
+):
+    """Old recorder states only stored the average; the total is rebuilt."""
+    mock_restore_cache(
+        hass,
+        [
+            State(BATTERY_ENTITY_ID, "4.0"),
+            State(AVERAGE_VALUE_SENSOR_ID, "0.2"),
+        ],
+    )
+    _entry, handle = await setup_battery()
+
+    assert handle._charge_state == pytest.approx(4.0)
+    assert handle._stored_energy_value == pytest.approx(0.2 * 4.0)
+    assert hass.states.get(AVERAGE_VALUE_SENSOR_ID).state == "0.2"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,35 @@
+"""Tests for the battery_sim switch platform."""
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from custom_components.battery_sim.const import PAUSE_BATTERY
+
+from .common import PAUSE_SWITCH_ID
+
+
+async def test_pause_switch_created_off(hass, setup_battery):
+    _entry, handle = await setup_battery()
+
+    state = hass.states.get(PAUSE_SWITCH_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert handle._switches[PAUSE_BATTERY] is False
+
+
+async def test_pause_switch_turn_on_and_off(hass, setup_battery):
+    _entry, handle = await setup_battery()
+
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": PAUSE_SWITCH_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert handle._switches[PAUSE_BATTERY] is True
+    assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_ON
+
+    await hass.services.async_call(
+        "switch", "turn_off", {"entity_id": PAUSE_SWITCH_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert handle._switches[PAUSE_BATTERY] is False
+    assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_OFF


### PR DESCRIPTION
Introduce pytest-based tests built on pytest-homeassistant-custom-component
covering the whole integration (171 tests, 96% line coverage):

- helpers: efficiency curve parsing/interpolation/validation, legacy input
  list generation, expected unique IDs, registry leftover/empty-device
  detection and purging
- core battery logic: charging/discharging in all operating modes, rate and
  SoC limits, efficiency curves, solar/inverter caps, tariffs and savings,
  stored-energy value accounting, cycle counting and degradation, reset,
  meter reading handlers (kWh/Wh, meter resets, unavailable states) and
  update scheduling incl. the minimum update interval
- setup/unload and all four services, including device lookup edge cases,
  plus YAML-based setup via discovery
- config flow (predefined and custom batteries, duplicate abort, invalid
  efficiency input) and options flow (main params, meters, tariffs,
  leftover cleanup)
- entity platforms: sensor states/attributes/restore, switch, select,
  number sliders (incl. minimum SoC floor clamping and restore) and the
  reset button

Add requirements_test.txt, pytest configuration in pyproject.toml, a GitHub
Actions workflow running the suite on every push/PR, and a short
development section in the README.

https://claude.ai/code/session_01EYeiMTYz6eYLp3Np25WjdH

## Summary by Sourcery

Add a pytest-based automated test suite for the battery_sim Home Assistant integration and wire it into local development and CI.

Build:
- Add pytest configuration and a test-only requirements file to support running the suite.

CI:
- Add a GitHub Actions workflow to run the test suite with coverage on every push and pull request.

Documentation:
- Document how to run the new test suite locally and note that tests run automatically in CI.

Tests:
- Introduce a comprehensive pytest test suite covering core battery logic, helpers, config/options flows, entity platforms, services, and legacy/YAML setups.
- Add shared test helpers and fixtures to simplify battery_sim test setup and teardown.