### PR TITLE
Persist battery mode and pause switch across restarts

### DIFF
--- a/custom_components/battery_sim/select.py
+++ b/custom_components/battery_sim/select.py
@@ -2,6 +2,8 @@
 import logging
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     DOMAIN,
@@ -16,6 +18,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_BATTERY_MODE = "battery_mode"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -39,7 +43,7 @@ async def async_setup_platform(
     return True
 
 
-class BatteryMode(SelectEntity):
+class BatteryMode(RestoreEntity, SelectEntity):
     """Select to set the battery operating mode."""
 
     def __init__(self, handle):
@@ -84,8 +88,14 @@ class BatteryMode(SelectEntity):
     def options(self):
         return [opt.replace("_", " ").capitalize() for opt in self._internal_options]
 
-    async def async_select_option(self, option: str):
-        internal_option = next(
+    @property
+    def extra_state_attributes(self):
+        """Expose the internal mode key so it survives a restart unambiguously."""
+        return {ATTR_BATTERY_MODE: self.handle._battery_mode}
+
+    def _internal_option(self, option: str):
+        """Map a displayed option back to its internal mode, or None if unknown."""
+        return next(
             (
                 opt
                 for opt in self._internal_options
@@ -94,6 +104,9 @@ class BatteryMode(SelectEntity):
             None,
         )
 
+    async def async_select_option(self, option: str):
+        internal_option = self._internal_option(option)
+
         if internal_option is None:
             _LOGGER.warning("Invalid option selected: %s", option)
             return
@@ -101,3 +114,28 @@ class BatteryMode(SelectEntity):
         self.handle._battery_mode = internal_option
         self.handle.async_trigger_update()
         self.schedule_update_ha_state(True)
+
+    async def async_added_to_hass(self):
+        """Restore the mode that was selected before the last restart."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is None or state.state in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return
+
+        # Prefer the internal key stored as an attribute; fall back to the
+        # displayed option for states written before that attribute existed.
+        restored_mode = state.attributes.get(ATTR_BATTERY_MODE)
+        if restored_mode not in self._internal_options:
+            restored_mode = self._internal_option(state.state)
+
+        if restored_mode is None:
+            _LOGGER.warning(
+                "Ignoring invalid restored battery mode '%s' for '%s'.",
+                state.state,
+                self._name,
+            )
+            return
+
+        self.handle._battery_mode = restored_mode
+        _LOGGER.debug("Restored battery mode for '%s' to %s", self._name, restored_mode)

--- a/custom_components/battery_sim/switch.py
+++ b/custom_components/battery_sim/switch.py
@@ -2,6 +2,8 @@
 import logging
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, CONF_BATTERY, PAUSE_BATTERY
 
@@ -47,7 +49,7 @@ async def async_setup_platform(
     return True
 
 
-class BatterySwitch(SwitchEntity):
+class BatterySwitch(RestoreEntity, SwitchEntity):
     """Switch to pause or resume the simulated battery."""
 
     def __init__(self, handle, switch_type, key, icon):
@@ -98,3 +100,16 @@ class BatterySwitch(SwitchEntity):
         self.handle.async_trigger_update()
         self.schedule_update_ha_state(True)
         return True
+
+    async def async_added_to_hass(self):
+        """Restore the switch position from before the last restart."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is None or state.state not in (STATE_ON, STATE_OFF):
+            return
+
+        self.handle._switches[self._switch_type] = state.state == STATE_ON
+        _LOGGER.debug(
+            "Restored %s for '%s' to %s", self._key, self._name, state.state
+        )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,11 @@
 """Tests for the battery_sim select platform."""
+from homeassistant.core import State
+
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
 from custom_components.battery_sim.const import (
     DEFAULT_MODE,
+    DISCHARGE_ONLY,
     FORCE_DISCHARGE,
     OVERRIDE_CHARGING,
     PAUSE_BATTERY,
@@ -69,3 +74,66 @@ async def test_invalid_option_is_ignored(hass, setup_battery, caplog):
 
     assert handle._battery_mode == DEFAULT_MODE
     assert "Invalid option selected" in caplog.text
+
+
+async def test_mode_exposes_internal_key_as_attribute(hass, setup_battery):
+    await setup_battery()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": MODE_SELECT_ID, "option": "Discharge only"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(MODE_SELECT_ID)
+    assert state.state == "Discharge only"
+    assert state.attributes["battery_mode"] == DISCHARGE_ONLY
+
+
+async def test_mode_restored_from_attribute(hass, setup_battery):
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                MODE_SELECT_ID,
+                "Discharge only",
+                {"battery_mode": DISCHARGE_ONLY},
+            )
+        ],
+    )
+
+    _entry, handle = await setup_battery()
+
+    assert handle._battery_mode == DISCHARGE_ONLY
+    assert hass.states.get(MODE_SELECT_ID).state == "Discharge only"
+
+
+async def test_mode_restored_from_state_without_attribute(hass, setup_battery):
+    """States stored before the attribute existed still restore."""
+    mock_restore_cache(hass, [State(MODE_SELECT_ID, "Force discharge")])
+
+    _entry, handle = await setup_battery()
+
+    assert handle._battery_mode == FORCE_DISCHARGE
+    assert hass.states.get(MODE_SELECT_ID).state == "Force discharge"
+
+
+async def test_invalid_restored_mode_falls_back_to_default(
+    hass, setup_battery, caplog
+):
+    mock_restore_cache(hass, [State(MODE_SELECT_ID, "Not a real mode")])
+
+    _entry, handle = await setup_battery()
+
+    assert handle._battery_mode == DEFAULT_MODE
+    assert "Ignoring invalid restored battery mode" in caplog.text
+
+
+async def test_unavailable_restored_mode_falls_back_to_default(hass, setup_battery):
+    mock_restore_cache(hass, [State(MODE_SELECT_ID, "unavailable")])
+
+    _entry, handle = await setup_battery()
+
+    assert handle._battery_mode == DEFAULT_MODE

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,5 +1,8 @@
 """Tests for the battery_sim switch platform."""
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import State
+
+from pytest_homeassistant_custom_component.common import mock_restore_cache
 
 from custom_components.battery_sim.const import PAUSE_BATTERY
 
@@ -30,6 +33,33 @@ async def test_pause_switch_turn_on_and_off(hass, setup_battery):
         "switch", "turn_off", {"entity_id": PAUSE_SWITCH_ID}, blocking=True
     )
     await hass.async_block_till_done()
+
+    assert handle._switches[PAUSE_BATTERY] is False
+    assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_OFF
+
+
+async def test_pause_switch_restored_on(hass, setup_battery):
+    mock_restore_cache(hass, [State(PAUSE_SWITCH_ID, STATE_ON)])
+
+    _entry, handle = await setup_battery()
+
+    assert handle._switches[PAUSE_BATTERY] is True
+    assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_ON
+
+
+async def test_pause_switch_restored_off(hass, setup_battery):
+    mock_restore_cache(hass, [State(PAUSE_SWITCH_ID, STATE_OFF)])
+
+    _entry, handle = await setup_battery()
+
+    assert handle._switches[PAUSE_BATTERY] is False
+    assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_OFF
+
+
+async def test_unavailable_restored_switch_stays_off(hass, setup_battery):
+    mock_restore_cache(hass, [State(PAUSE_SWITCH_ID, STATE_UNAVAILABLE)])
+
+    _entry, handle = await setup_battery()
 
     assert handle._switches[PAUSE_BATTERY] is False
     assert hass.states.get(PAUSE_SWITCH_ID).state == STATE_OFF


### PR DESCRIPTION
The Battery Mode select was a plain SelectEntity, so the mode lived only
in memory on the battery handle. On every Home Assistant restart the
handle was rebuilt with DEFAULT_MODE and a user who had selected e.g.
"Discharge only" silently went back to "Default mode".

Make the select a RestoreEntity and reapply the previous mode to the
handle in async_added_to_hass. The internal mode key is also published as
a `battery_mode` attribute and preferred when restoring, so restoration
does not depend on the displayed option string; states written before
this change still restore via the displayed option. Unknown, unavailable
and unrecognised states fall back to the default mode.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Di7AakEQJqcoUW64W14Mxo

## Summary by Sourcery

Persist battery simulation mode and pause switch state across Home Assistant restarts.

Bug Fixes:
- Restore the previously selected battery mode after restart using Home Assistant's state restoration instead of defaulting to the default mode.
- Ensure invalid, unknown, or unavailable restored battery modes fall back to the default mode.
- Restore the pause switch on/off state after restart while treating unavailable restored states as off.

Enhancements:
- Expose the internal battery mode key as a dedicated entity attribute to decouple restoration from the human-readable option label.

Tests:
- Add tests covering attribute exposure, mode restoration from both attribute and legacy state, invalid/unknown mode fallbacks, and pause switch state restoration behavior.