### PR TITLE
Publish sensor and number units as native units

### DIFF
--- a/custom_components/battery_sim/number.py
+++ b/custom_components/battery_sim/number.py
@@ -113,7 +113,7 @@ class BatterySlider(RestoreNumber):
         else:
             _LOGGER.debug("Reached undefined state in number.py")
         self._attr_icon = icon
-        self._attr_unit_of_measurement = unit
+        self._attr_native_unit_of_measurement = unit
         self._attr_mode = "box"
         
     @property

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -335,7 +335,7 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
         return SensorStateClass.TOTAL
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._units
 
@@ -501,11 +501,6 @@ class SimulatedBattery(RestoreEntity, SensorEntity):
 
     @property
     def native_unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return UnitOfEnergy.KILO_WATT_HOUR
-
-    @property
-    def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return UnitOfEnergy.KILO_WATT_HOUR
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,7 @@
 """Tests for the battery_sim number platform."""
 import pytest
 
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import State
 
 from custom_components.battery_sim.const import CONF_MINIMUM_USER_SELECTABLE_SOC
@@ -61,6 +62,28 @@ async def test_sliders_created_with_expected_ranges(hass, setup_battery):
     maximum_soc = hass.states.get(MAXIMUM_SOC_NUMBER_ID)
     # The slider is initialised with the integer 100, so no decimal is shown.
     assert maximum_soc.state == "100"
+
+
+async def test_sliders_expose_their_units(hass, setup_battery):
+    """Sliders must publish a unit; NumberEntity only reads the native attribute."""
+    await setup_battery()
+
+    assert (
+        hass.states.get(CHARGE_LIMIT_NUMBER_ID).attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == "kW"
+    )
+    assert (
+        hass.states.get(DISCHARGE_LIMIT_NUMBER_ID).attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == "kW"
+    )
+    assert (
+        hass.states.get(MINIMUM_SOC_NUMBER_ID).attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == "%"
+    )
+    assert (
+        hass.states.get(MAXIMUM_SOC_NUMBER_ID).attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == "%"
+    )
 
 
 async def test_minimum_soc_slider_floor_from_config(hass, setup_battery):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,8 @@
 """Tests for the battery_sim sensor platform."""
 import pytest
 
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfEnergy
+from homeassistant.helpers import entity_registry as er
 from homeassistant.core import State
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -82,6 +83,34 @@ async def test_all_sensors_created_with_initial_values(hass, setup_battery):
 
     # No solar sensor configured, so no solar power cap entity.
     assert hass.states.get(SOLAR_CAP_SENSOR_ID) is None
+
+
+async def test_display_sensor_unit_can_be_overridden_by_the_user(
+    hass, setup_battery
+):
+    """The unit must be published as the native one so HA can convert it.
+
+    Home Assistant converts a sensor's value from its native unit to the unit
+    the user picked in the entity settings. A sensor that only overrides
+    `unit_of_measurement` bypasses that conversion entirely.
+    """
+    await setup_battery()
+    entity_registry = er.async_get(hass)
+
+    assert (
+        hass.states.get(ENERGY_SAVED_SENSOR_ID).attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == UnitOfEnergy.KILO_WATT_HOUR
+    )
+
+    entity_registry.async_update_entity_options(
+        ENERGY_SAVED_SENSOR_ID,
+        "sensor",
+        {"unit_of_measurement": UnitOfEnergy.WATT_HOUR},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_SAVED_SENSOR_ID)
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
 
 
 async def test_solar_power_cap_sensor_created_with_solar_config(


### PR DESCRIPTION
## Summary
This PR updates the battery_sim custom component to use Home Assistant's `native_unit_of_measurement` property instead of the deprecated `unit_of_measurement` property. This allows Home Assistant's built-in unit conversion system to work properly when users override units in entity settings.

## Key Changes
- **Sensor platform**: Changed `unit_of_measurement` to `native_unit_of_measurement` in the `EnergySavedSensor` class and updated the base sensor class property name
- **Number platform**: Changed `_attr_unit_of_measurement` to `_attr_native_unit_of_measurement` for all number entities (charge limit, discharge limit, minimum SOC, maximum SOC sliders)
- **Tests**: Added comprehensive test coverage to verify:
  - Sensor units can be overridden by users through entity registry options
  - Number entities properly expose their units in state attributes

## Implementation Details
The change from `unit_of_measurement` to `native_unit_of_measurement` is important because:
- Home Assistant uses `native_unit_of_measurement` to identify the sensor's base unit
- It then automatically converts values to the user's preferred unit (set in entity settings)
- Using only `unit_of_measurement` bypasses this conversion system entirely
- This ensures proper unit handling when users customize their preferred units in Home Assistant's UI

https://claude.ai/code/session_016VnoTpAsViNzpwPhYorA18

## Summary by Sourcery

Align battery_sim entities with Home Assistant’s native unit handling to support user-configurable unit overrides and proper unit conversion.

New Features:
- Allow the display unit of the energy saved sensor to be overridden via entity registry options.
- Ensure number slider entities publish their units so they are available in state attributes.

Enhancements:
- Switch sensors and number entities from unit_of_measurement to native_unit_of_measurement for compatibility with Home Assistant’s unit conversion system.

Tests:
- Add tests verifying sensor unit overrides through entity registry options and unit exposure for number sliders.