### PR TITLE
Require Home Assistant 2026.8 and adapt to its APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: "actions/checkout@v7"
       - uses: "actions/setup-python@v7"
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
       - name: Install test dependencies
         run: pip install -r requirements_test.txt

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Please note this is a simulation and a real battery may behave differently and n
 
 ## Setup
 
+This integration requires Home Assistant **2026.8.0** or newer.
+
 The easiest way to get battery_sim is to use HACS to add it as an integration. If you do not want to use HACS, copy this repository into the `custom_components` folder in your Home Assistant configuration directory.
 
 After installation, create one or more batteries. The recommended approach is to go to **Settings > Devices & Services**, click **Add Integration**, search for **Battery Simulation**, and work through the dialog for each battery you want to simulate.
@@ -245,7 +247,7 @@ to your configuration.yaml and then restarting. If you leave it to run for a few
 
 The integration has a test suite under `tests/` based on
 [pytest-homeassistant-custom-component](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component).
-To run it locally (Python 3.13 recommended):
+To run it locally (Python 3.14 required, matching Home Assistant 2026.8):
 
 ```
 pip install -r requirements_test.txt

--- a/custom_components/battery_sim/button.py
+++ b/custom_components/battery_sim/button.py
@@ -5,6 +5,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import DOMAIN, CONF_BATTERY, RESET_BATTERY, MESSAGE_TYPE_GENERAL
+from .helpers import battery_entity_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +61,9 @@ class BatteryButton(ButtonEntity):
         self._button_type = button_type
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier
-        self._name = f"{handle._name} ".replace("_", " ") + f"{button_type}".replace("_", " ").capitalize()
+        self._name = battery_entity_name(
+            handle._name, button_type.replace("_", " ").capitalize()
+        )
         self._attr_unique_id = f"{handle._name} - {button_type}"
         self._type = type
 

--- a/custom_components/battery_sim/config_flow.py
+++ b/custom_components/battery_sim/config_flow.py
@@ -74,7 +74,7 @@ class BatterySetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Return flow options."""
-        return BatteryOptionsFlowHandler(config_entry)
+        return BatteryOptionsFlowHandler()
 
     @staticmethod
     def _validate_efficiency_fields(user_input):
@@ -296,16 +296,10 @@ class BatterySetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow for battery."""
 
-    def __init__(self, config_entry=None):
+    def __init__(self):
         """Initialize options flow."""
-        self._config_entry_compat = config_entry
         self.updated_entry = None
         self.current_input_entry = None
-
-    @property
-    def _battery_config_entry(self):
-        """Return the config entry for both old and new Home Assistant cores."""
-        return getattr(self, "config_entry", None) or self._config_entry_compat
 
     @staticmethod
     def _validate_efficiency_fields(user_input):
@@ -323,9 +317,7 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
-        config_entry = self._battery_config_entry
-        self.updated_entry = config_entry.data.copy()
-        self._active_config_entry = config_entry
+        self.updated_entry = self.config_entry.data.copy()
         if CONF_INPUT_LIST not in self.updated_entry:
             self.updated_entry[CONF_INPUT_LIST] = generate_input_list(
                 config=self.updated_entry
@@ -351,7 +343,7 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
                 entity_reg,
                 device_reg,
                 self.updated_entry,
-                self._active_config_entry.entry_id,
+                self.config_entry.entry_id,
             )
         )
         if removed_entity_ids:
@@ -423,9 +415,9 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
                 else:
                     self.updated_entry.pop(CONF_NOMINAL_INVERTER_POWER, None)
                 self.hass.config_entries.async_update_entry(
-                    self._active_config_entry,
+                    self.config_entry,
                     data=self.updated_entry,
-                    options=self._active_config_entry.options,
+                    options=self.config_entry.options,
                 )
                 return await self.async_step_init()
 
@@ -517,9 +509,9 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
                 if input[SENSOR_ID] == user_input[CONF_INPUT_LIST]:
                     self.updated_entry[CONF_INPUT_LIST].remove(input)
             self.hass.config_entries.async_update_entry(
-                self._active_config_entry,
+                self.config_entry,
                 data=self.updated_entry,
-                options=self._active_config_entry.options,
+                options=self.config_entry.options,
             )
             return await self.async_step_init()
 
@@ -603,9 +595,9 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_no_tariff_info(self, user_input=None):
         self.current_input_entry[TARIFF_TYPE] = NO_TARIFF_INFO
         self.hass.config_entries.async_update_entry(
-            self._active_config_entry,
+            self.config_entry,
             data=self.updated_entry,
-            options=self._active_config_entry.options,
+            options=self.config_entry.options,
         )
         return await self.async_step_init()
 
@@ -614,9 +606,9 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
             self.current_input_entry[TARIFF_TYPE] = FIXED_TARIFF
             self.current_input_entry[FIXED_TARIFF] = user_input[FIXED_TARIFF]
             self.hass.config_entries.async_update_entry(
-                self._active_config_entry,
+                self.config_entry,
                 data=self.updated_entry,
-                options=self._active_config_entry.options,
+                options=self.config_entry.options,
             )
             return await self.async_step_init()
 
@@ -639,9 +631,9 @@ class BatteryOptionsFlowHandler(config_entries.OptionsFlow):
             self.current_input_entry[TARIFF_TYPE] = TARIFF_SENSOR
             self.current_input_entry[TARIFF_SENSOR] = user_input[TARIFF_SENSOR]
             self.hass.config_entries.async_update_entry(
-                self._active_config_entry,
+                self.config_entry,
                 data=self.updated_entry,
-                options=self._active_config_entry.options,
+                options=self.config_entry.options,
             )
             return await self.async_step_init()
 

--- a/custom_components/battery_sim/helpers.py
+++ b/custom_components/battery_sim/helpers.py
@@ -243,13 +243,22 @@ CONTROL_ENTITY_UNIQUE_ID_SUFFIXES = (
 )
 
 
-def battery_device_identifiers(config, entry_id=None):
+def battery_entity_name(battery_name, entity_suffix):
+    """Return the name of a battery sub-entity.
+
+    The battery name is used verbatim as the prefix because it is also the
+    device name. These entities do not set `has_entity_name`, so Home Assistant
+    strips the device name off the front of the entity name before it composes
+    the entity ID from the device and entity name parts. Reformatting the
+    battery name here (replacing underscores with spaces, for example) breaks
+    that match, and the device name ends up in the entity ID twice.
+    """
+    return f"{battery_name} {entity_suffix}"
+
+
+def battery_device_identifiers(config, entry_id):
     """Return device identifiers used by this integration for a battery config."""
-    identifiers = []
-    if entry_id is not None:
-        identifiers.append((DOMAIN, entry_id))
-    identifiers.append((DOMAIN, config[CONF_NAME]))
-    return identifiers
+    return [(DOMAIN, entry_id), (DOMAIN, config[CONF_NAME])]
 
 
 def expected_entity_unique_ids(config):
@@ -274,11 +283,11 @@ def expected_entity_unique_ids(config):
     return unique_ids
 
 
-def battery_device_registry_ids(device_registry, config, entry_id=None):
+def battery_device_registry_ids(device_registry, config, entry_id):
     """Return device registry IDs for known current and legacy battery identifiers."""
     device_ids = []
     for identifier in battery_device_identifiers(config, entry_id):
-        device = device_registry.async_get_device({identifier})
+        device = device_registry.async_get_device_by_identifier(identifier, entry_id)
         if device is not None and device.id not in device_ids:
             device_ids.append(device.id)
     return device_ids
@@ -295,7 +304,7 @@ def _entity_registry_entries_for_device(entity_registry, device_id):
 
 
 def find_leftover_entity_registry_entries(
-    entity_registry, device_registry, config, entry_id=None
+    entity_registry, device_registry, config, entry_id
 ):
     """Return registered battery entities that are not used by current settings."""
     expected_unique_ids = expected_entity_unique_ids(config)
@@ -311,7 +320,7 @@ def find_leftover_entity_registry_entries(
     return leftovers
 
 
-def find_empty_battery_devices(entity_registry, device_registry, config, entry_id=None):
+def find_empty_battery_devices(entity_registry, device_registry, config, entry_id):
     """Return registered battery devices that no longer have any entities."""
     empty_devices = []
     for device_id in battery_device_registry_ids(device_registry, config, entry_id):
@@ -329,7 +338,7 @@ def find_empty_battery_devices(entity_registry, device_registry, config, entry_i
 
 
 def purge_leftover_battery_registry_entries(
-    entity_registry, device_registry, config, entry_id=None
+    entity_registry, device_registry, config, entry_id
 ):
     """Delete leftover battery entities, then delete battery devices left empty.
 

--- a/custom_components/battery_sim/number.py
+++ b/custom_components/battery_sim/number.py
@@ -16,6 +16,7 @@ from .const import (
     MINIMUM_SOC,
     MAXIMUM_SOC,
 )
+from .helpers import battery_entity_name
  
 import logging
 
@@ -95,7 +96,9 @@ class BatterySlider(RestoreNumber):
         self._precision = precision
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier
-        self._name = f"{handle._name} ".replace("_", " ") + f"{slider_type}".replace("_", " ").capitalize()
+        self._name = battery_entity_name(
+            handle._name, slider_type.replace("_", " ").capitalize()
+        )
         self._attr_unique_id = f"{handle._name} - {slider_type}"
         if key == "charge_limit":
             self._max_value = handle._max_charge_rate

--- a/custom_components/battery_sim/select.py
+++ b/custom_components/battery_sim/select.py
@@ -14,6 +14,7 @@ from .const import (
     DEFAULT_MODE,
     ICON_FULL,
 )
+from .helpers import battery_entity_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class BatteryMode(SelectEntity):
         self.handle = handle
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier
-        self._name = f"{handle._name} ".replace("_", " ") + "Battery Mode"
+        self._name = battery_entity_name(handle._name, "Battery Mode")
         self._attr_unique_id = f"{handle._name} - Battery Mode"
         self._internal_options = [
             DEFAULT_MODE,

--- a/custom_components/battery_sim/sensor.py
+++ b/custom_components/battery_sim/sensor.py
@@ -66,6 +66,7 @@ from .const import (
     MESSAGE_TYPE_BATTERY_UPDATE,
     SENSOR_ID,
 )
+from .helpers import battery_entity_name
 
 _LOGGER = logging.getLogger(__name__)
 _INVALID_RESTORED_STATES = {None, "", STATE_UNKNOWN, STATE_UNAVAILABLE}
@@ -206,7 +207,9 @@ class DisplayOnlySensor(RestoreEntity, SensorEntity):
         """Initialize the display only sensors for the battery."""
         self._handle = handle
         self._units = units
-        self._name = f"{handle._name} ".replace("_", " ") + f"{sensor_name}".replace("_", " ").capitalize()
+        self._name = battery_entity_name(
+            handle._name, sensor_name.replace("_", " ").capitalize()
+        )
         self._attr_unique_id = f"{handle._name} - {sensor_name}"
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier
@@ -555,7 +558,9 @@ class BatteryStatus(SensorEntity):
     def __init__(self, handle, sensor_name):
         self.handle = handle
         self._date_recording_started = time.asctime()
-        self._name = f"{handle._name} ".replace("_", " ") + f"{sensor_name}".replace("_", " ").capitalize()
+        self._name = battery_entity_name(
+            handle._name, sensor_name.replace("_", " ").capitalize()
+        )
         self._attr_unique_id = f"{handle._name} - {sensor_name}"
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier

--- a/custom_components/battery_sim/switch.py
+++ b/custom_components/battery_sim/switch.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 
 from .const import DOMAIN, CONF_BATTERY, PAUSE_BATTERY
+from .helpers import battery_entity_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,9 +58,8 @@ class BatterySwitch(SwitchEntity):
         self._switch_type = switch_type
         self._device_name = handle._name
         self._device_identifier = handle.device_identifier
-        self._name = (
-            f"{handle._name} ".replace("_", " ")
-            + f"{switch_type}".replace("_", " ").capitalize()
+        self._name = battery_entity_name(
+            handle._name, switch_type.replace("_", " ").capitalize()
         )
         self._attr_unique_id = f"{handle._name} - {switch_type}"
         self._type = type

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "Battery Simulator",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2026.8.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,1 @@
-pytest-homeassistant-custom-component==0.13.316
+pytest-homeassistant-custom-component==0.13.354

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -409,8 +409,8 @@ class TestOptionsFlow:
         entry, _handle = await setup_battery()
         entity_registry = er.async_get(hass)
         device_registry = dr.async_get(hass)
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.entry_id)}
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.entry_id), entry.entry_id
         )
         stale = entity_registry.async_get_or_create(
             "sensor",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -277,11 +277,7 @@ class TestExpectedEntityUniqueIds:
         assert f"legacy - {GRID_EXPORT_SIM}" in unique_ids
 
 
-def test_battery_device_identifiers_without_entry_id():
-    assert battery_device_identifiers(base_config()) == [(DOMAIN, BATTERY_NAME)]
-
-
-def test_battery_device_identifiers_with_entry_id():
+def test_battery_device_identifiers():
     assert battery_device_identifiers(base_config(), "entry123") == [
         (DOMAIN, "entry123"),
         (DOMAIN, BATTERY_NAME),
@@ -309,8 +305,8 @@ class TestRegistryCleanupHelpers:
         entry, _handle = await setup_battery()
         entity_registry = er.async_get(hass)
         device_registry = dr.async_get(hass)
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.entry_id)}
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.entry_id), entry.entry_id
         )
         assert device is not None
 
@@ -405,7 +401,9 @@ class TestRegistryCleanupHelpers:
         assert device_registry.async_get(legacy_device.id) is None
         # The active battery device and its entities stay untouched.
         assert (
-            device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, entry.entry_id), entry.entry_id
+            )
             is not None
         )
         assert entity_registry.async_get("sensor.test_battery") is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,7 +29,9 @@ SERVICES = (
 def get_battery_device(hass, entry):
     """Return the device registry entry created for a battery config entry."""
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert device is not None
     return device
 


### PR DESCRIPTION
Raises the minimum supported Home Assistant version to **2026.8.0** and adapts the integration to the API changes announced for 2026.2 → 2026.8, dropping the compatibility code that existed to span older cores.

## What changed

### Device registry — entry-scoped identifier lookup

[Devices are restricted to a single config entry](https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/) makes identifiers unique *per config entry* instead of globally, and deprecates `DeviceRegistry.async_get_device()` because an identifier lookup can now match several devices (removed in 2027.8).

`helpers.py` used it to resolve the battery's current and legacy device identifiers. It now uses the entry-scoped `async_get_device_by_identifier(identifier, config_entry_id)`. That lookup requires the config entry id, so `entry_id` became a mandatory argument through `battery_device_identifiers()`, `battery_device_registry_ids()`, `find_leftover_entity_registry_entries()`, `find_empty_battery_devices()` and `purge_leftover_battery_registry_entries()`. Every production caller already passed it.

Nothing else in this integration was affected: the devices only carry `battery_sim`-prefixed identifiers and no connections, so the 2026.8 device split does not touch them, and none of `via_device`, `primary_config_entry`, `DeviceEntry.config_entries` or the `helpers.device` linking functions are used.

`test_battery_device_identifiers_without_entry_id` was removed, since `entry_id` is no longer optional.

### Options flow — use the config entry provided by core

`OptionsFlow.config_entry` is supplied by Home Assistant, so `BatteryOptionsFlowHandler` no longer takes a config entry in its constructor, and the `_config_entry_compat` / `_battery_config_entry` / `_active_config_entry` indirection that existed to work with both old and new cores is gone.

### Entity naming — stop duplicating the battery name in entity IDs

Names are now built through a shared `battery_entity_name()` helper that uses the battery name verbatim, which restores the entity IDs the integration generated before. The helper's docstring records why the prefix must not be reformatted.

Note this only ever affected *newly created* entities — existing ones keep their registered entity ID.

### Version and tooling

- `hacs.json` gains `"homeassistant": "2026.8.0"` so HACS refuses to install on older cores.
- `requirements_test.txt` → `pytest-homeassistant-custom-component==0.13.354` (Home Assistant 2026.8.0).
- CI Python 3.13 → 3.14, which Home Assistant 2026.8 requires.
- README documents the minimum core and Python versions.

---
_Generated by [Claude Code](https://claude.ai/code/session_016VnoTpAsViNzpwPhYorA18)_

